### PR TITLE
add ir module in kernel && add kernel dump

### DIFF
--- a/luisa_compute/src/lang/mod.rs
+++ b/luisa_compute/src/lang/mod.rs
@@ -1172,7 +1172,7 @@ impl KernelBuilder {
             let artifact = if options.async_compile {
                 ShaderArtifact::Async(AsyncShaderArtifact::new(
                     self.device.clone(),
-                    module,
+                    module.clone(),
                     shader_options,
                     name,
                 ))
@@ -1185,6 +1185,7 @@ impl KernelBuilder {
                 artifact,
                 device: self.device.clone(),
                 resource_tracker,
+                module: module,
             })
         })
     }

--- a/luisa_compute/src/runtime.rs
+++ b/luisa_compute/src/runtime.rs
@@ -705,6 +705,7 @@ pub struct RawKernel {
     pub(crate) artifact: ShaderArtifact,
     #[allow(dead_code)]
     pub(crate) resource_tracker: ResourceTracker,
+    pub(crate) module: CArc<KernelModule>,
 }
 pub struct CallableArgEncoder {
     pub(crate) args: Vec<NodeRef>,
@@ -953,6 +954,9 @@ impl<T: KernelArg> Kernel<T> {
         let handle = self.inner.unwrap();
         let device = &self.inner.device;
         device.inner.shader_cache_dir(handle)
+    }
+    pub fn dump(&self) -> String {
+        ir::debug::dump_ir_human_readable(&self.inner.module.module)
     }
 }
 pub trait AsKernelArg<T: KernelArg>: KernelArg {}


### PR DESCRIPTION
Store the IR Module inside `RawKernel`, enabling the user to dump IR as a `String`.