### PR TITLE
Replace `make_float4` with `Float4::expr`, etc.

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,9 +168,9 @@ As in the C++ EDSL, we additionally supports the following vector/matrix types. 
 Bool2 // bool2 in C++
 Bool3 // bool3 in C++
 Bool4 // bool4 in C++
-Vec2 // float2 in C++
-Vec3 // float3 in C++
-Vec4 // float4 in C++
+Float2 // float2 in C++
+Float3 // float3 in C++
+Float4 // float4 in C++
 Int2 // int2 in C++
 Int3 // int3 in C++
 Int4 // int4 in C++
@@ -185,7 +185,7 @@ Array types `[T;N]` are also supported and their proxy types are `ArrayExpr<T, N
 
 Most operators are already overloaded with the only exception is comparision. We cannot overload comparision operators as `PartialOrd` cannot return a DSL type. Instead, use `cmpxx` methods such as `cmpgt, cmpeq`, etc. To cast a primitive/vector into another type, use `v.type()`. For example:
 ```rust
-let iv = make_int2(1,1,1);
+let iv = Int2::expr(1, 1, 1);
 let fv = iv.float(); //fv is Expr<Float2>
 let bv = fv.bool(); // bv is Expr<Bool2>
 ```

--- a/luisa_compute/examples/mpm.rs
+++ b/luisa_compute/examples/mpm.rs
@@ -87,8 +87,8 @@ fn main() {
 
     let index = |xy: Expr<Uint2>| -> Expr<u32> {
         let p = xy.clamp(
-            make_uint2(0, 0),
-            make_uint2(N_GRID as u32 - 1, N_GRID as u32 - 1),
+            Uint2::expr(0, 0),
+            Uint2::expr(N_GRID as u32 - 1, N_GRID as u32 - 1),
         );
         p.x() + p.y() * N_GRID as u32
     };
@@ -113,11 +113,11 @@ fn main() {
         ];
         let stress = -4.0f32 * DT * E * P_VOL * (J.var().read(p) - 1.0f32) / (DX * DX);
         let affine =
-            Expr::<Mat2>::eye(make_float2(stress, stress)) + P_MASS as f32 * C.var().read(p);
+            Expr::<Mat2>::eye(Float2::expr(stress, stress)) + P_MASS as f32 * C.var().read(p);
         let vp = v.var().read(p);
         for ii in 0..9 {
             let (i, j) = (ii % 3, ii / 3);
-            let offset = make_int2(i as i32, j as i32);
+            let offset = Int2::expr(i as i32, j as i32);
             let dpos = (offset.float() - fx) * DX;
             let weight = w[i].x() * w[j].y();
             let vadd = weight * (P_MASS * vp + affine * dpos);
@@ -132,7 +132,7 @@ fn main() {
         let coord = dispatch_id().xy();
         let i = index(coord);
         let v = var!(Float2);
-        v.store(make_float2(
+        v.store(Float2::expr(
             grid_v.var().read(i * 2u32),
             grid_v.var().read(i * 2u32 + 1u32),
         ));
@@ -170,15 +170,15 @@ fn main() {
         ];
         let new_v = var!(Float2);
         let new_C = var!(Mat2);
-        new_v.store(make_float2(0.0f32, 0.0f32));
-        new_C.store(make_float2x2(make_float2(0., 0.), make_float2(0., 0.)));
+        new_v.store(Float2::expr(0.0f32, 0.0f32));
+        new_C.store(Mat2::expr(Float2::expr(0., 0.), Float2::expr(0., 0.)));
         for ii in 0..9 {
             let (i, j) = (ii % 3, ii / 3);
-            let offset = make_int2(i as i32, j as i32);
+            let offset = Int2::expr(i as i32, j as i32);
             let dpos = (offset.float() - fx) * DX;
             let weight = w[i].x() * w[j].y();
             let idx = index((base + offset).uint());
-            let g_v = make_float2(
+            let g_v = Float2::expr(
                 grid_v.var().read(idx * 2u32),
                 grid_v.var().read(idx * 2u32 + 1u32),
             );
@@ -195,14 +195,14 @@ fn main() {
     let clear_display = device.create_kernel_async::<fn()>(&|| {
         display.var().write(
             dispatch_id().xy(),
-            make_float4(0.1f32, 0.2f32, 0.3f32, 1.0f32),
+            Float4::expr(0.1f32, 0.2f32, 0.3f32, 1.0f32),
         );
     });
     let draw_particles = device.create_kernel_async::<fn()>(&|| {
         let p = dispatch_id().x();
         for i in -1..=1 {
             for j in -1..=1 {
-                let pos = (x.var().read(p) * RESOLUTION as f32).int() + make_int2(i, j);
+                let pos = (x.var().read(p) * RESOLUTION as f32).int() + Int2::expr(i, j);
                 if_!(
                     pos.x().cmpge(0i32)
                         & pos.x().cmplt(RESOLUTION as i32)
@@ -210,8 +210,8 @@ fn main() {
                         & pos.y().cmplt(RESOLUTION as i32),
                     {
                         display.var().write(
-                            make_uint2(pos.x().uint(), RESOLUTION - 1u32 - pos.y().uint()),
-                            make_float4(0.4f32, 0.6f32, 0.6f32, 1.0f32),
+                            Uint2::expr(pos.x().uint(), RESOLUTION - 1u32 - pos.y().uint()),
+                            Float4::expr(0.4f32, 0.6f32, 0.6f32, 1.0f32),
                         );
                     }
                 );

--- a/luisa_compute/examples/path_tracer.rs
+++ b/luisa_compute/examples/path_tracer.rs
@@ -285,10 +285,10 @@ fn main() {
 
                 let generate_ray = |p: Expr<Float2>| -> Expr<Ray> {
                     const FOV: f32 = 27.8f32 * std::f32::consts::PI / 180.0f32;
-                    let origin = make_float3(-0.01f32, 0.995f32, 5.0f32);
+                    let origin = Float3::expr(-0.01f32, 0.995f32, 5.0f32);
 
                     let pixel = origin
-                        + make_float3(
+                        + Float3::expr(
                         p.x() * f32::tan(0.5f32 * FOV),
                         p.y() * f32::tan(0.5f32 * FOV),
                         -1.0f32,
@@ -304,9 +304,9 @@ fn main() {
                 let make_onb = |normal: Expr<Float3>| -> Expr<Onb> {
                     let binormal = if_!(
                         normal.x().abs().cmpgt(normal.z().abs()), {
-                            make_float3(-normal.y(), normal.x(), 0.0f32)
+                            Float3::expr(-normal.y(), normal.x(), 0.0f32)
                         }, else {
-                            make_float3(0.0f32, -normal.z(), normal.y())
+                            Float3::expr(0.0f32, -normal.z(), normal.y())
                         }
                     );
                     let tangent = binormal.cross(normal).normalize();
@@ -316,7 +316,7 @@ fn main() {
                 let cosine_sample_hemisphere = |u: Expr<Float2>| {
                     let r = u.x().sqrt();
                     let phi = 2.0f32 * std::f32::consts::PI * u.y();
-                    make_float3(r * phi.cos(), r * phi.sin(), (1.0f32 - u.x()).sqrt())
+                    Float3::expr(r * phi.cos(), r * phi.sin(), (1.0f32 - u.x()).sqrt())
                 };
 
                 let coord = dispatch_id().xy();
@@ -327,24 +327,24 @@ fn main() {
                 let rx = lcg(state);
                 let ry = lcg(state);
 
-                let pixel = (coord.float() + make_float2(rx, ry)) / frame_size * 2.0f32 - 1.0f32;
+                let pixel = (coord.float() + Float2::expr(rx, ry)) / frame_size * 2.0f32 - 1.0f32;
 
                 let radiance = var!(Float3);
-                radiance.store(make_float3(0.0f32, 0.0f32, 0.0f32));
+                radiance.store(Float3::expr(0.0f32, 0.0f32, 0.0f32));
                 for_range(0..SPP_PER_DISPATCH as u32, |_| {
-                    let init_ray = generate_ray(pixel * make_float2(1.0f32, -1.0f32));
+                    let init_ray = generate_ray(pixel * Float2::expr(1.0f32, -1.0f32));
                     let ray = var!(Ray);
                     ray.store(init_ray);
 
                     let beta = var!(Float3);
-                    beta.store(make_float3(1.0f32, 1.0f32, 1.0f32));
+                    beta.store(Float3::expr(1.0f32, 1.0f32, 1.0f32));
                     let pdf_bsdf = var!(f32);
                     pdf_bsdf.store(0.0f32);
 
-                    let light_position = make_float3(-0.24f32, 1.98f32, 0.16f32);
-                    let light_u = make_float3(-0.24f32, 1.98f32, -0.22f32) - light_position;
-                    let light_v = make_float3(0.23f32, 1.98f32, 0.16f32) - light_position;
-                    let light_emission = make_float3(17.0f32, 12.0f32, 4.0f32);
+                    let light_position = Float3::expr(-0.24f32, 1.98f32, 0.16f32);
+                    let light_u = Float3::expr(-0.24f32, 1.98f32, -0.22f32) - light_position;
+                    let light_v = Float3::expr(0.23f32, 1.98f32, 0.16f32) - light_position;
+                    let light_emission = Float3::expr(17.0f32, 12.0f32, 4.0f32);
                     let light_area = light_u.cross(light_v).length();
                     let light_normal = light_u.cross(light_v).normalize();
 
@@ -414,13 +414,13 @@ fn main() {
                         let onb = make_onb(n);
                         let ux = lcg(state);
                         let uy = lcg(state);
-                        let new_direction = onb.to_world(cosine_sample_hemisphere(make_float2(ux, uy)));
+                        let new_direction = onb.to_world(cosine_sample_hemisphere(Float2::expr(ux, uy)));
                         *ray.get_mut() = make_ray(pp, new_direction, 0.0f32.into(), std::f32::MAX.into());
                         *beta.get_mut() *= albedo;
                         pdf_bsdf.store(cos_wi * std::f32::consts::FRAC_1_PI);
 
                         // russian roulette
-                        let l = make_float3(0.212671f32, 0.715160f32, 0.072169f32).dot(*beta);
+                        let l = Float3::expr(0.212671f32, 0.715160f32, 0.072169f32).dot(*beta);
                         if_!(l.cmpeq(0.0f32), { break_(); });
                         let q = l.max(0.05f32);
                         let r = lcg(state);
@@ -432,28 +432,29 @@ fn main() {
                 });
                 radiance.store(radiance.load() / SPP_PER_DISPATCH as f32);
                 seed_image.write(coord, *state);
-                if_!(radiance.load().is_nan().any(), { radiance.store(make_float3(0.0f32, 0.0f32, 0.0f32)); });
+                if_!(radiance.load().is_nan().any(), { radiance.store(Float3::expr(0.0f32, 0.0f32, 0.0f32)); });
                 let radiance = radiance.load().clamp(0.0f32, 30.0f32);
                 let old = image.read(dispatch_id().xy());
                 let spp = old.w();
                 let radiance = radiance + old.xyz();
-                image.write(dispatch_id().xy(), make_float4(radiance.x(), radiance.y(), radiance.z(), spp + 1.0f32));
+                image.write(dispatch_id().xy(), Float4::expr(radiance.x(), radiance.y(), radiance.z(), spp + 1.0f32));
             },
         )
         ;
-    let display = device.create_kernel_async::<fn(Tex2d<Float4>, Tex2d<Float4>)>(&|acc, display| {
-        set_block_size([16, 16, 1]);
-        let coord = dispatch_id().xy();
-        let radiance = acc.read(coord);
-        let spp = radiance.w();
-        let radiance = radiance.xyz() / spp;
+    let display =
+        device.create_kernel_async::<fn(Tex2d<Float4>, Tex2d<Float4>)>(&|acc, display| {
+            set_block_size([16, 16, 1]);
+            let coord = dispatch_id().xy();
+            let radiance = acc.read(coord);
+            let spp = radiance.w();
+            let radiance = radiance.xyz() / spp;
 
-        // workaround a rust-analyzer bug
-        let r = 1.055f32 * radiance.powf(1.0 / 2.4) - 0.055;
+            // workaround a rust-analyzer bug
+            let r = 1.055f32 * radiance.powf(1.0 / 2.4) - 0.055;
 
-        let srgb = Float3Expr::select(radiance.cmplt(0.0031308), radiance * 12.92, r);
-        display.write(coord, make_float4(srgb.x(), srgb.y(), srgb.z(), 1.0f32));
-    });
+            let srgb = Float3Expr::select(radiance.cmplt(0.0031308), radiance * 12.92, r);
+            display.write(coord, Float4::expr(srgb.x(), srgb.y(), srgb.z(), 1.0f32));
+        });
     let img_w = 1024;
     let img_h = 1024;
     let acc_img = device.create_tex2d::<Float4>(PixelStorage::Float4, img_w, img_h, 1);

--- a/luisa_compute/examples/ray_query.rs
+++ b/luisa_compute/examples/ray_query.rs
@@ -111,10 +111,10 @@ fn main() {
     let rt_kernel = device.create_kernel::<fn()>(&|| {
         let accel = accel.var();
         let px = dispatch_id().xy();
-        let xy = px.float() / make_float2(img_w as f32, img_h as f32);
+        let xy = px.float() / Float2::expr(img_w as f32, img_h as f32);
         let xy = 2.0 * xy - 1.0;
-        let o = make_float3(0.0, 0.0, -2.0);
-        let d = make_float3(xy.x(), xy.y(), 0.0) - o;
+        let o = Float3::expr(0.0, 0.0, -2.0);
+        let d = Float3::expr(xy.x(), xy.y(), 0.0) - o;
         let d = d.normalize();
         let ray = rtx::RayExpr::new(o + const_(translate), 1e-3, d, 1e9);
         let hit = accel.query_all(
@@ -123,9 +123,9 @@ fn main() {
             RayQuery {
                 on_triangle_hit: |candidate: TriangleCandidate| {
                     let bary = candidate.bary();
-                    let uvw = make_float3(1.0 - bary.x() - bary.y(), bary.x(), bary.y());
+                    let uvw = Float3::expr(1.0 - bary.x() - bary.y(), bary.x(), bary.y());
                     let t = candidate.committed_ray_t();
-                    if_!(px.cmpeq(make_uint2(400, 400)).all(), {
+                    if_!(px.cmpeq(Uint2::expr(400, 400)).all(), {
                         debug_hit_t.write(0, t);
                         debug_hit_t.write(1, candidate.ray().tmax());
                     });
@@ -151,7 +151,7 @@ fn main() {
                             .length()
                             - sphere.radius();
                         if_!(dist.cmplt(0.001), {
-                            if_!(px.cmpeq(make_uint2(400, 400)).all(), {
+                            if_!(px.cmpeq(Uint2::expr(400, 400)).all(), {
                                 debug_hit_t.write(2, *t);
                                 debug_hit_t.write(3, candidate.ray().tmax());
                             });
@@ -170,7 +170,7 @@ fn main() {
             hit.triangle_hit(),
             {
                 let bary = hit.bary();
-                let uvw = make_float3(1.0 - bary.x() - bary.y(), bary.x(), bary.y());
+                let uvw = Float3::expr(1.0 - bary.x() - bary.y(), bary.x(), bary.y());
                 uvw
             },
             else,
@@ -184,19 +184,19 @@ fn main() {
                             + ray.dir().unpack() * hit.committed_ray_t()
                             - sphere.center())
                         .normalize();
-                        let light_dir = make_float3(1.0, 0.6, -0.2).normalize();
-                        let light = make_float3(1.0, 1.0, 1.0);
-                        let ambient = make_float3(0.1, 0.1, 0.1);
+                        let light_dir = Float3::expr(1.0, 0.6, -0.2).normalize();
+                        let light = Float3::expr(1.0, 1.0, 1.0);
+                        let ambient = Float3::expr(0.1, 0.1, 0.1);
                         let diffuse = light * normal.dot(light_dir).max(0.0);
                         let color = ambient + diffuse;
                         color
                     },
                     else,
-                    { make_float3(0.0, 0.0, 0.0) }
+                    { Float3::expr(0.0, 0.0, 0.0) }
                 )
             }
         );
-        img.write(px, make_float4(color.x(), color.y(), color.z(), 1.0));
+        img.write(px, Float4::expr(color.x(), color.y(), color.z(), 1.0));
     });
     let event_loop = EventLoop::new();
     let window = winit::window::WindowBuilder::new()

--- a/luisa_compute/examples/raytracing.rs
+++ b/luisa_compute/examples/raytracing.rs
@@ -4,11 +4,11 @@ use image::Rgb;
 #[allow(unused_imports)]
 use luisa::prelude::*;
 use luisa_compute as luisa;
+use winit::event::Event as WinitEvent;
 use winit::{
-    event::{WindowEvent},
+    event::WindowEvent,
     event_loop::{ControlFlow, EventLoop},
 };
-use winit::event::Event as WinitEvent;
 fn main() {
     use luisa::*;
     init_logger();
@@ -46,20 +46,20 @@ fn main() {
     let rt_kernel = device.create_kernel::<fn()>(&|| {
         let accel = accel.var();
         let px = dispatch_id().xy();
-        let xy = px.float() / make_float2(img_w as f32, img_h as f32);
+        let xy = px.float() / Float2::expr(img_w as f32, img_h as f32);
         let xy = 2.0 * xy - 1.0;
-        let o = make_float3(0.0, 0.0, -1.0);
-        let d = make_float3(xy.x(), xy.y(), 0.0) - o;
+        let o = Float3::expr(0.0, 0.0, -1.0);
+        let d = Float3::expr(xy.x(), xy.y(), 0.0) - o;
         let d = d.normalize();
         let ray = rtx::RayExpr::new(o, 1e-3, d, 1e9);
         let hit = accel.trace_closest(ray);
         let img = img.view(0).var();
         let color = select(
             hit.valid(),
-            make_float3(hit.u(), hit.v(), 1.0),
-            make_float3(0.0, 0.0, 0.0),
+            Float3::expr(hit.u(), hit.v(), 1.0),
+            Float3::expr(0.0, 0.0, 0.0),
         );
-        img.write(px, make_float4(color.x(), color.y(), color.z(), 1.0));
+        img.write(px, Float4::expr(color.x(), color.y(), color.z(), 1.0));
     });
     let event_loop = EventLoop::new();
     let window = winit::window::WindowBuilder::new()

--- a/luisa_compute/examples/sdf_renderer.rs
+++ b/luisa_compute/examples/sdf_renderer.rs
@@ -37,8 +37,8 @@ fn main() {
         device.create_kernel::<fn(Buffer<f32>, Buffer<Sphere>)>(
             &|buf_x: BufferVar<f32>, spheres: BufferVar<Sphere>| {
                 let tid = dispatch_id().x();
-                let o = make_float3(0.0, 0.0, -2.0);
-                let d = make_float3(0.0, 0.0, 1.0);
+                let o = Float3::expr(0.0, 0.0, -2.0);
+                let d = Float3::expr(0.0, 0.0, 1.0);
                 let sphere = spheres.read(0);
                 let t = var!(f32);
                 while_!(t.load().cmplt(10.0), {

--- a/luisa_compute/examples/shadertoy.rs
+++ b/luisa_compute/examples/shadertoy.rs
@@ -22,26 +22,26 @@ fn main() {
     });
 
     let palette = device.create_callable::<fn(Expr<f32>) -> Expr<Float3>>(&|d| {
-        make_float3(0.2, 0.7, 0.9).lerp(make_float3(1.0, 0.0, 1.0), Float3Expr::splat(d))
+        Float3::expr(0.2, 0.7, 0.9).lerp(Float3::expr(1.0, 0.0, 1.0), Float3Expr::splat(d))
     });
     let rotate =
         device.create_callable::<fn(Expr<Float2>, Expr<f32>) -> Expr<Float2>>(&|mut p, a| {
             let c = a.cos();
             let s = a.sin();
-            make_float2(p.dot(make_float2(c, s)), p.dot(make_float2(-s, c)))
+            Float2::expr(p.dot(Float2::expr(c, s)), p.dot(Float2::expr(-s, c)))
         });
     let map = device.create_callable::<fn(Expr<Float3>, Expr<f32>) -> Expr<f32>>(&|mut p, time| {
         for i in 0..8 {
             let t = time * 0.2;
             let r = rotate.call(p.xz(), t);
-            p = make_float3(r.x(), r.y(), p.y()).xzy();
+            p = Float3::expr(r.x(), r.y(), p.y()).xzy();
             let r = rotate.call(p.xy(), t * 1.89);
-            p = make_float3(r.x(), r.y(), p.z());
-            p = make_float3(p.x().abs() - 0.5, p.y(), p.z().abs() - 0.5)
+            p = Float3::expr(r.x(), r.y(), p.z());
+            p = Float3::expr(p.x().abs() - 0.5, p.y(), p.z().abs() - 0.5)
         }
         Float3Expr::splat(1.0).copysign(p).dot(p) * 0.2
     });
-    let rm = device.create_callable::<fn(Expr<Float3>, Expr<Float3>, Expr<f32>)-> Expr<Float4>>(
+    let rm = device.create_callable::<fn(Expr<Float3>, Expr<Float3>, Expr<f32>) -> Expr<Float4>>(
         &|ro, rd, time| {
             let t = var!(f32, 0.0);
             let col = var!(Float3);
@@ -54,21 +54,21 @@ fn main() {
                 *t.get_mut() += *d;
             });
             let col = *col;
-            make_float4(col.x(), col.y(), col.z(), 1.0 / (100.0 * *d))
+            Float4::expr(col.x(), col.y(), col.z(), 1.0 / (100.0 * *d))
         },
     );
-    let clear_kernel = device.create_kernel::<fn(Tex2d<Float4>,)>(&|img| {
+    let clear_kernel = device.create_kernel::<fn(Tex2d<Float4>)>(&|img| {
         let coord = dispatch_id().xy();
-        img.write(coord, make_float4(0.3, 0.4, 0.5, 1.0));
+        img.write(coord, Float4::expr(0.3, 0.4, 0.5, 1.0));
     });
     let main_kernel = device.create_kernel::<fn(Tex2d<Float4>, f32)>(&|img, time| {
         let xy = dispatch_id().xy();
         let resolution = dispatch_size().xy();
         let uv = (xy.float() - resolution.float() * 0.5) / resolution.x().float();
-        let r = rotate.call(make_float2(0.0, -50.0), time);
-        let ro = make_float3(r.x(), r.y(), 0.0).xzy();
+        let r = rotate.call(Float2::expr(0.0, -50.0), time);
+        let ro = Float3::expr(r.x(), r.y(), 0.0).xzy();
         let cf = (-ro).normalize();
-        let cs = cf.cross(make_float3(0.0, 10.0, 0.0)).normalize();
+        let cs = cf.cross(Float3::expr(0.0, 10.0, 0.0)).normalize();
         let cu = cf.cross(cs).normalize();
         let uuv = ro + cf * 3.0 + uv.x() * cs + uv.y() * cu;
         let rd = (uuv - ro).normalize();
@@ -77,6 +77,6 @@ fn main() {
         let alpha = col.w();
         let old = img.read(xy).xyz();
         let accum = color.lerp(old, Float3Expr::splat(alpha));
-        img.write(xy, make_float4(accum.x(), accum.y(), accum.z(), 1.0));
+        img.write(xy, Float4::expr(accum.x(), accum.y(), accum.z(), 1.0));
     });
 }

--- a/luisa_compute/src/lang/math.rs
+++ b/luisa_compute/src/lang/math.rs
@@ -546,6 +546,12 @@ macro_rules! impl_vec_proxy {
                 FromNode::from_node(__extract::<$scalar>(self.node, index))
             }
         }
+        impl $vec {
+            #[inline]
+            pub fn expr($($comp: impl Into<Expr<$scalar>>), *) -> $expr_proxy {
+                $expr_proxy::new($($comp.into()), *)
+            }
+        }
     };
 }
 
@@ -646,6 +652,12 @@ macro_rules! impl_mat_proxy {
                 Expr::<$vec>::from_node(__extract::<$vec>(self.node, index))
             }
         }
+        impl $mat {
+            #[inline]
+            pub fn expr($($comp: impl Into<Expr<$vec>>), *) -> $expr_proxy {
+                $expr_proxy::new($($comp.into()), *)
+            }
+        }
     };
 }
 
@@ -663,7 +675,18 @@ impl_vec_proxy!(Float4, Float4Expr, Float4Var, f32, Float32, 4, x, y, z, w);
 
 impl_vec_proxy!(Double2, Double2Expr, Double2Var, f64, Float64, 2, x, y);
 impl_vec_proxy!(Double3, Double3Expr, Double3Var, f64, Float64, 3, x, y, z);
-impl_vec_proxy!(Double4, Double4Expr, Double4Var, f64, Float64, 4, x, y, z, w);
+impl_vec_proxy!(
+    Double4,
+    Double4Expr,
+    Double4Var,
+    f64,
+    Float64,
+    4,
+    x,
+    y,
+    z,
+    w
+);
 
 impl_vec_proxy!(Ushort2, Ushort2Expr, Ushort2Var, u16, Uint16, 2, x, y);
 impl_vec_proxy!(Ushort3, Ushort3Expr, Ushort3Var, u16, Uint16, 3, x, y, z);
@@ -1668,10 +1691,10 @@ impl Mul<Float2Expr> for Mat2Expr {
 }
 impl Mat2Expr {
     pub fn fill(e: impl Into<Expr<f32>> + Copy) -> Self {
-        Self::new(make_float2(e, e), make_float2(e, e))
+        Self::new(Float2::expr(e, e), Float2::expr(e, e))
     }
     pub fn eye(e: Expr<Float2>) -> Self {
-        Self::new(make_float2(e.x(), 0.0), make_float2(0.0, e.y()))
+        Self::new(Float2::expr(e.x(), 0.0), Float2::expr(0.0, e.y()))
     }
     pub fn inverse(&self) -> Self {
         Mat2Expr::from_node(__current_scope(|s| {
@@ -1706,16 +1729,16 @@ impl Mul<Float3Expr> for Mat3Expr {
 impl Mat3Expr {
     pub fn fill(e: impl Into<PrimExpr<f32>> + Copy) -> Self {
         Self::new(
-            make_float3(e, e, e),
-            make_float3(e, e, e),
-            make_float3(e, e, e),
+            Float3::expr(e, e, e),
+            Float3::expr(e, e, e),
+            Float3::expr(e, e, e),
         )
     }
     pub fn eye(e: Expr<Float3>) -> Self {
         Self::new(
-            make_float3(e.x(), 0.0, 0.0),
-            make_float3(0.0, e.y(), 0.0),
-            make_float3(0.0, 0.0, e.z()),
+            Float3::expr(e.x(), 0.0, 0.0),
+            Float3::expr(0.0, e.y(), 0.0),
+            Float3::expr(0.0, 0.0, e.z()),
         )
     }
     pub fn inverse(&self) -> Self {
@@ -1751,18 +1774,18 @@ impl_arith_binop_for_mat!(Mat3, f32, Mat3Expr);
 impl Mat4Expr {
     pub fn fill(e: impl Into<PrimExpr<f32>> + Copy) -> Self {
         Self::new(
-            make_float4(e, e, e, e),
-            make_float4(e, e, e, e),
-            make_float4(e, e, e, e),
-            make_float4(e, e, e, e),
+            Float4::expr(e, e, e, e),
+            Float4::expr(e, e, e, e),
+            Float4::expr(e, e, e, e),
+            Float4::expr(e, e, e, e),
         )
     }
     pub fn eye(e: Expr<Float4>) -> Self {
         Self::new(
-            make_float4(e.x(), 0.0, 0.0, 0.0),
-            make_float4(0.0, e.y(), 0.0, 0.0),
-            make_float4(0.0, 0.0, e.z(), 0.0),
-            make_float4(0.0, 0.0, 0.0, e.w()),
+            Float4::expr(e.x(), 0.0, 0.0, 0.0),
+            Float4::expr(0.0, e.y(), 0.0, 0.0),
+            Float4::expr(0.0, 0.0, e.z(), 0.0),
+            Float4::expr(0.0, 0.0, 0.0, e.w()),
         )
     }
     pub fn inverse(&self) -> Self {
@@ -1782,193 +1805,6 @@ impl Mat4Expr {
     }
 }
 impl_arith_binop_for_mat!(Mat4, f32, Mat4Expr);
-
-#[inline]
-pub fn make_half2<X: Into<PrimExpr<f16>>, Y: Into<PrimExpr<f16>>>(x: X, y: Y) -> Expr<Half2> {
-    Expr::<Half2>::new(x.into(), y.into())
-}
-#[inline]
-pub fn make_half3<X: Into<PrimExpr<f16>>, Y: Into<PrimExpr<f16>>, Z: Into<PrimExpr<f16>>>(
-    x: X,
-    y: Y,
-    z: Z,
-) -> Expr<Half3> {
-    Expr::<Half3>::new(x.into(), y.into(), z.into())
-}
-#[inline]
-pub fn make_half4<
-    X: Into<PrimExpr<f16>>,
-    Y: Into<PrimExpr<f16>>,
-    Z: Into<PrimExpr<f16>>,
-    W: Into<PrimExpr<f16>>,
->(
-    x: X,
-    y: Y,
-    z: Z,
-    w: W,
-) -> Expr<Half4> {
-    Expr::<Half4>::new(x.into(), y.into(), z.into(), w.into())
-}
-
-#[inline]
-pub fn make_float2<X: Into<PrimExpr<f32>>, Y: Into<PrimExpr<f32>>>(x: X, y: Y) -> Expr<Float2> {
-    Expr::<Float2>::new(x.into(), y.into())
-}
-#[inline]
-pub fn make_float3<X: Into<PrimExpr<f32>>, Y: Into<PrimExpr<f32>>, Z: Into<PrimExpr<f32>>>(
-    x: X,
-    y: Y,
-    z: Z,
-) -> Expr<Float3> {
-    Expr::<Float3>::new(x.into(), y.into(), z.into())
-}
-#[inline]
-pub fn make_float4<
-    X: Into<PrimExpr<f32>>,
-    Y: Into<PrimExpr<f32>>,
-    Z: Into<PrimExpr<f32>>,
-    W: Into<PrimExpr<f32>>,
->(
-    x: X,
-    y: Y,
-    z: Z,
-    w: W,
-) -> Expr<Float4> {
-    Expr::<Float4>::new(x.into(), y.into(), z.into(), w.into())
-}
-#[inline]
-pub fn make_float2x2<X: Into<Expr<Float2>>, Y: Into<Expr<Float2>>>(x: X, y: Y) -> Expr<Mat2> {
-    Expr::<Mat2>::new(x.into(), y.into())
-}
-#[inline]
-pub fn make_float3x3<X: Into<Expr<Float3>>, Y: Into<Expr<Float3>>, Z: Into<Expr<Float3>>>(
-    x: X,
-    y: Y,
-    z: Z,
-) -> Expr<Mat3> {
-    Expr::<Mat3>::new(x.into(), y.into(), z.into())
-}
-#[inline]
-pub fn make_float4x4<
-    X: Into<Expr<Float4>>,
-    Y: Into<Expr<Float4>>,
-    Z: Into<Expr<Float4>>,
-    W: Into<Expr<Float4>>,
->(
-    x: X,
-    y: Y,
-    z: Z,
-    w: W,
-) -> Expr<Mat4> {
-    Expr::<Mat4>::new(x.into(), y.into(), z.into(), w.into())
-}
-
-#[inline]
-pub fn make_int2<X: Into<PrimExpr<i32>>, Y: Into<PrimExpr<i32>>>(x: X, y: Y) -> Expr<Int2> {
-    Expr::<Int2>::new(x.into(), y.into())
-}
-#[inline]
-pub fn make_int3<X: Into<PrimExpr<i32>>, Y: Into<PrimExpr<i32>>, Z: Into<PrimExpr<i32>>>(
-    x: X,
-    y: Y,
-    z: Z,
-) -> Expr<Int3> {
-    Expr::<Int3>::new(x.into(), y.into(), z.into())
-}
-#[inline]
-pub fn make_int4<
-    X: Into<PrimExpr<i32>>,
-    Y: Into<PrimExpr<i32>>,
-    Z: Into<PrimExpr<i32>>,
-    W: Into<PrimExpr<i32>>,
->(
-    x: X,
-    y: Y,
-    z: Z,
-    w: W,
-) -> Expr<Int4> {
-    Expr::<Int4>::new(x.into(), y.into(), z.into(), w.into())
-}
-#[inline]
-pub fn make_uint2<X: Into<PrimExpr<u32>>, Y: Into<PrimExpr<u32>>>(x: X, y: Y) -> Expr<Uint2> {
-    Expr::<Uint2>::new(x.into(), y.into())
-}
-#[inline]
-pub fn make_uint3<X: Into<PrimExpr<u32>>, Y: Into<PrimExpr<u32>>, Z: Into<PrimExpr<u32>>>(
-    x: X,
-    y: Y,
-    z: Z,
-) -> Expr<Uint3> {
-    Expr::<Uint3>::new(x.into(), y.into(), z.into())
-}
-#[inline]
-pub fn make_uint4<
-    X: Into<PrimExpr<u32>>,
-    Y: Into<PrimExpr<u32>>,
-    Z: Into<PrimExpr<u32>>,
-    W: Into<PrimExpr<u32>>,
->(
-    x: X,
-    y: Y,
-    z: Z,
-    w: W,
-) -> Expr<Uint4> {
-    Expr::<Uint4>::new(x.into(), y.into(), z.into(), w.into())
-}
-
-#[inline]
-pub fn make_short2<X: Into<PrimExpr<i16>>, Y: Into<PrimExpr<i16>>>(x: X, y: Y) -> Expr<Short2> {
-    Expr::<Short2>::new(x.into(), y.into())
-}
-#[inline]
-pub fn make_short3<X: Into<PrimExpr<i16>>, Y: Into<PrimExpr<i16>>, Z: Into<PrimExpr<i16>>>(
-    x: X,
-    y: Y,
-    z: Z,
-) -> Expr<Short3> {
-    Expr::<Short3>::new(x.into(), y.into(), z.into())
-}
-#[inline]
-pub fn make_short4<
-    X: Into<PrimExpr<i16>>,
-    Y: Into<PrimExpr<i16>>,
-    Z: Into<PrimExpr<i16>>,
-    W: Into<PrimExpr<i16>>,
->(
-    x: X,
-    y: Y,
-    z: Z,
-    w: W,
-) -> Expr<Short4> {
-    Expr::<Short4>::new(x.into(), y.into(), z.into(), w.into())
-}
-
-#[inline]
-pub fn make_ushort2<X: Into<PrimExpr<u16>>, Y: Into<PrimExpr<u16>>>(x: X, y: Y) -> Expr<Ushort2> {
-    Expr::<Ushort2>::new(x.into(), y.into())
-}
-#[inline]
-pub fn make_ushort3<X: Into<PrimExpr<u16>>, Y: Into<PrimExpr<u16>>, Z: Into<PrimExpr<u16>>>(
-    x: X,
-    y: Y,
-    z: Z,
-) -> Expr<Ushort3> {
-    Expr::<Ushort3>::new(x.into(), y.into(), z.into())
-}
-#[inline]
-pub fn make_ushort4<
-    X: Into<PrimExpr<u16>>,
-    Y: Into<PrimExpr<u16>>,
-    Z: Into<PrimExpr<u16>>,
-    W: Into<PrimExpr<u16>>,
->(
-    x: X,
-    y: Y,
-    z: Z,
-    w: W,
-) -> Expr<Ushort4> {
-    Expr::<Ushort4>::new(x.into(), y.into(), z.into(), w.into())
-}
 
 #[cfg(test)]
 mod test {

--- a/luisa_compute/src/lang/mod.rs
+++ b/luisa_compute/src/lang/mod.rs
@@ -1,7 +1,6 @@
-use std::backtrace::Backtrace;
 use std::collections::HashSet;
 use std::marker::PhantomData;
-use std::{any::Any, collections::HashMap, fmt::Debug, rc::Rc, sync::Arc};
+use std::{any::Any, fmt::Debug, rc::Rc, sync::Arc};
 use std::{env, unreachable};
 
 use crate::lang::traits::VarCmp;
@@ -13,18 +12,15 @@ use bumpalo::Bump;
 use indexmap::IndexMap;
 pub use ir::ir::NodeRef;
 use ir::ir::{
+    new_node, BasicBlock, Binding, Capture, Const, CpuCustomOp, Func, Instruction, IrBuilder,
+    KernelModule, Module, ModuleKind, Node, PhiIncoming,
+};
+use ir::ir::{
     ArrayType, CallableModule, CallableModuleRef, ModuleFlags, ModulePools, SwitchCase,
     UserNodeData, INVALID_REF,
 };
 pub use ir::CArc;
 use ir::Pooled;
-use ir::{
-    ir::{
-        new_node, BasicBlock, Binding, Capture, Const, CpuCustomOp, Func, Instruction, IrBuilder,
-        KernelModule, Module, ModuleKind, Node, PhiIncoming,
-    },
-    transform::{self, Transform},
-};
 
 use luisa_compute_ir as ir;
 
@@ -34,10 +30,9 @@ pub use luisa_compute_ir::{
     ir::{StructType, Type},
     TypeOf,
 };
-use math::Uint3;
-use std::cell::{Cell, RefCell, UnsafeCell};
+use std::cell::{Cell, RefCell};
 use std::ffi::CString;
-use std::ops::{Bound, Deref, DerefMut, RangeBounds};
+use std::ops::{Deref, DerefMut};
 use std::sync::atomic::AtomicUsize;
 // use self::math::Uint3;
 pub mod math;
@@ -50,12 +45,15 @@ pub use math::*;
 pub use poly::*;
 pub use printer::*;
 
+#[allow(dead_code)]
 pub(crate) static KERNEL_ID: AtomicUsize = AtomicUsize::new(0);
 // prevent node being shared across kernels
 // TODO: replace NodeRef with SafeNodeRef
 #[derive(Clone, Copy, Debug)]
 pub(crate) struct SafeNodeRef {
+    #[allow(dead_code)]
     pub(crate) node: NodeRef,
+    #[allow(dead_code)]
     pub(crate) kernel_id: usize,
 }
 pub trait Value: Copy + ir::TypeOf + 'static {

--- a/luisa_compute/src/lang/printer.rs
+++ b/luisa_compute/src/lang/printer.rs
@@ -6,6 +6,7 @@ use std::sync::atomic::AtomicBool;
 
 pub type LogFn = Box<dyn Fn(&[*const u32]) + Send + Sync>;
 struct PrinterItem {
+    #[allow(dead_code)]
     level: log::Level,
     log_fn: LogFn,
     count: usize,
@@ -123,7 +124,8 @@ impl Printer {
         let item_id = items.len() as u32;
 
         if_!(
-            offset.cmplt(data.len().uint()) & (offset + 1 + args.count as u32).cmple(data.len().uint()),
+            offset.cmplt(data.len().uint())
+                & (offset + 1 + args.count as u32).cmple(data.len().uint()),
             {
                 data.atomic_fetch_add(0, 1);
                 data.write(offset, item_id);
@@ -194,7 +196,7 @@ impl<'a> Scope<'a> {
             let items = data.items.read();
             let mut i = 2;
             let item_count = host_data[0] as usize;
-            for j in 0..item_count {
+            for _j in 0..item_count {
                 if i >= host_data.len() {
                     break;
                 }

--- a/luisa_compute/src/resource.rs
+++ b/luisa_compute/src/resource.rs
@@ -912,7 +912,7 @@ impl_io_texel!(
     f32,
     Float4,
     |x: Float4Expr| x.xy(),
-    |x: Float2Expr| { make_float4(x.x(), x.y(), 0.0, 0.0) }
+    |x: Float2Expr| { Float4::expr(x.x(), x.y(), 0.0, 0.0) }
 );
 impl_io_texel!(Float4, f32, Float4, |x: Float4Expr| x, |x: Float4Expr| x);
 
@@ -927,10 +927,10 @@ impl_io_texel!(u32, u32, Uint4, |x: Uint4Expr| x.x(), |x| Uint4Expr::splat(
 ));
 impl_io_texel!(i32, i32, Int4, |x: Int4Expr| x.x(), |x| Int4Expr::splat(x));
 impl_io_texel!(Uint2, u32, Uint4, |x: Uint4Expr| x.xy(), |x: Uint2Expr| {
-    make_uint4(x.x(), x.y(), 0u32, 0u32)
+    Uint4::expr(x.x(), x.y(), 0u32, 0u32)
 });
 impl_io_texel!(Int2, i32, Int4, |x: Int4Expr| x.xy(), |x: Int2Expr| {
-    make_int4(x.x(), x.y(), 0i32, 0i32)
+    Int4::expr(x.x(), x.y(), 0i32, 0i32)
 });
 impl_io_texel!(Uint4, u32, Uint4, |x: Uint4Expr| x, |x| x);
 impl_io_texel!(Int4, i32, Int4, |x: Int4Expr| x, |x| x);

--- a/luisa_compute/src/resource.rs
+++ b/luisa_compute/src/resource.rs
@@ -1004,7 +1004,9 @@ impl_storage_texel!([f16; 4], Byte4, f32, Float2, Float4, Int2, Int4, Uint2, Uin
 // `T` is the read out type of the texture, which is not necessarily the same as the storage type
 // In fact, the texture can be stored in any format as long as it can be converted to `T`
 pub struct Tex2d<T: IoTexel> {
+    #[allow(dead_code)]
     pub(crate) width: u32,
+    #[allow(dead_code)]
     pub(crate) height: u32,
     pub(crate) handle: Arc<TextureHandle>,
     pub(crate) marker: std::marker::PhantomData<T>,
@@ -1013,8 +1015,11 @@ pub struct Tex2d<T: IoTexel> {
 // `T` is the read out type of the texture, which is not necessarily the same as the storage type
 // In fact, the texture can be stored in any format as long as it can be converted to `T`
 pub struct Tex3d<T: IoTexel> {
+    #[allow(dead_code)]
     pub(crate) width: u32,
+    #[allow(dead_code)]
     pub(crate) height: u32,
+    #[allow(dead_code)]
     pub(crate) depth: u32,
     pub(crate) handle: Arc<TextureHandle>,
     pub(crate) marker: std::marker::PhantomData<T>,
@@ -1573,10 +1578,7 @@ impl BindlessArrayVar {
         };
         v
     }
-    pub fn byte_address_buffer(
-        &self,
-        buffer_index: impl Into<Expr<u32>>,
-    ) -> BindlessByteBufferVar {
+    pub fn byte_address_buffer(&self, buffer_index: impl Into<Expr<u32>>) -> BindlessByteBufferVar {
         let v = BindlessByteBufferVar {
             array: self.node,
             buffer_index: buffer_index.into(),

--- a/luisa_compute/src/rtx.rs
+++ b/luisa_compute/src/rtx.rs
@@ -41,6 +41,7 @@ pub(crate) struct ProceduralPrimitiveHandle {
     pub(crate) device: Device,
     pub(crate) handle: api::ProceduralPrimitive,
     pub(crate) native_handle: *mut std::ffi::c_void,
+    #[allow(dead_code)]
     pub(crate) aabb_buffer: Arc<BufferHandle>,
 }
 impl Drop for ProceduralPrimitiveHandle {
@@ -85,7 +86,9 @@ pub(crate) struct MeshHandle {
     pub(crate) device: Device,
     pub(crate) handle: api::Mesh,
     pub(crate) native_handle: *mut std::ffi::c_void,
+    #[allow(dead_code)]
     pub(crate) vbuffer: Arc<BufferHandle>,
+    #[allow(dead_code)]
     pub(crate) ibuffer: Arc<BufferHandle>,
 }
 impl Drop for MeshHandle {
@@ -148,7 +151,8 @@ impl Accel {
         let mut flags =
             api::AccelBuildModificationFlags::PRIMITIVE | AccelBuildModificationFlags::TRANSFORM;
 
-        flags |= api::AccelBuildModificationFlags::VISIBILITY | api::AccelBuildModificationFlags::USER_ID;
+        flags |= api::AccelBuildModificationFlags::VISIBILITY
+            | api::AccelBuildModificationFlags::USER_ID;
 
         if opaque {
             flags |= api::AccelBuildModificationFlags::OPAQUE_ON;
@@ -183,7 +187,8 @@ impl Accel {
     ) {
         let mut flags = api::AccelBuildModificationFlags::PRIMITIVE;
         dbg!(flags);
-        flags |= api::AccelBuildModificationFlags::VISIBILITY | api::AccelBuildModificationFlags::USER_ID;
+        flags |= api::AccelBuildModificationFlags::VISIBILITY
+            | api::AccelBuildModificationFlags::USER_ID;
 
         if opaque {
             flags |= api::AccelBuildModificationFlags::OPAQUE_ON;
@@ -372,8 +377,8 @@ pub enum HitType {
 
 pub fn offset_ray_origin(p: Expr<Float3>, n: Expr<Float3>) -> Expr<Float3> {
     lazy_static! {
-        static ref F: Callable<fn(Expr<Float3>, Expr<Float3>)-> Expr<Float3>> =
-            create_static_callable::<fn(Expr<Float3>, Expr<Float3>)->Expr<Float3>>(|p, n| {
+        static ref F: Callable<fn(Expr<Float3>, Expr<Float3>) -> Expr<Float3>> =
+            create_static_callable::<fn(Expr<Float3>, Expr<Float3>) -> Expr<Float3>>(|p, n| {
                 const ORIGIN: f32 = 1.0f32 / 32.0f32;
                 const FLOAT_SCALE: f32 = 1.0f32 / 65536.0f32;
                 const INT_SCALE: f32 = 256.0f32;

--- a/luisa_compute/src/runtime.rs
+++ b/luisa_compute/src/runtime.rs
@@ -367,7 +367,7 @@ impl Device {
             modifications: RwLock::new(HashMap::new()),
         }
     }
-    pub fn create_callable<'a, S: CallableSignature<'a>>(&self, f:S::Fn) -> S::Callable {
+    pub fn create_callable<'a, S: CallableSignature<'a>>(&self, f: S::Fn) -> S::Callable {
         let mut builder = KernelBuilder::new(Some(self.clone()), false);
         let raw_callable = CallableBuildFn::build_callable(&f, None, &mut builder);
         S::wrap_raw_callable(raw_callable)
@@ -835,6 +835,7 @@ impl<'a> CommandList<'a> {
     pub fn extend<I: IntoIterator<Item = Command<'a>>>(&mut self, commands: I) {
         self.commands.extend(commands);
     }
+    #[allow(dead_code)]
     pub fn push(&mut self, command: Command<'a>) {
         self.commands.push(command);
     }
@@ -864,6 +865,7 @@ pub struct Command<'a> {
 pub(crate) struct AsyncShaderArtifact {
     shader: Option<api::CreatedShaderInfo>,
     // strange naming, huh?
+    #[allow(dead_code)]
     name: Arc<CString>,
 }
 

--- a/luisa_compute/tests/autodiff.rs
+++ b/luisa_compute/tests/autodiff.rs
@@ -290,7 +290,7 @@ fn autodiff_vec3_reduce_add_manual() {
         let x = inputs[0];
         let y = inputs[1];
         let z = inputs[2];
-        let v = make_float3(x, y, z);
+        let v = Float3::expr(x, y, z);
         v.x() + v.y() + v.z()
     });
 }
@@ -301,7 +301,7 @@ fn autodiff_vec3_reduce_prod_manual() {
         let x = inputs[0];
         let y = inputs[1];
         let z = inputs[2];
-        let v = make_float3(x, y, z);
+        let v = Float3::expr(x, y, z);
         v.x() * v.y() * v.z()
     });
 }
@@ -311,7 +311,7 @@ fn autodiff_vec3_reduce_add() {
         let x = inputs[0];
         let y = inputs[1];
         let z = inputs[2];
-        let v = make_float3(x, y, z);
+        let v = Float3::expr(x, y, z);
         v.reduce_sum()
     });
 }
@@ -321,7 +321,7 @@ fn autodiff_vec3_reduce_mul() {
         let x = inputs[0];
         let y = inputs[1];
         let z = inputs[2];
-        let v = make_float3(x, y, z);
+        let v = Float3::expr(x, y, z);
         v.reduce_prod()
     });
 }
@@ -331,7 +331,7 @@ fn autodiff_vec3_dot() {
         let x = inputs[0];
         let y = inputs[1];
         let z = inputs[2];
-        let v = make_float3(x, y, z);
+        let v = Float3::expr(x, y, z);
         v.dot(v)
     });
 }
@@ -341,7 +341,7 @@ fn autodiff_vec3_length() {
         let x = inputs[0];
         let y = inputs[1];
         let z = inputs[2];
-        let v = make_float3(x, y, z);
+        let v = Float3::expr(x, y, z);
         v.length()
     });
 }
@@ -351,7 +351,7 @@ fn autodiff_vec3_length_squared() {
         let x = inputs[0];
         let y = inputs[1];
         let z = inputs[2];
-        let v = make_float3(x, y, z);
+        let v = Float3::expr(x, y, z);
         v.length_squared()
     });
 }
@@ -361,21 +361,21 @@ fn autodiff_vec3_normalize() {
         let x = inputs[0];
         let y = inputs[1];
         let z = inputs[2];
-        let v = make_float3(x, y, z);
+        let v = Float3::expr(x, y, z);
         v.normalize().x()
     });
     autodiff_helper(-10.0..10.0, 1024 * 1024, 3, |inputs| {
         let x = inputs[0];
         let y = inputs[1];
         let z = inputs[2];
-        let v = make_float3(x, y, z);
+        let v = Float3::expr(x, y, z);
         v.normalize().y()
     });
     autodiff_helper(-10.0..10.0, 1024 * 1024, 3, |inputs| {
         let x = inputs[0];
         let y = inputs[1];
         let z = inputs[2];
-        let v = make_float3(x, y, z);
+        let v = Float3::expr(x, y, z);
         v.normalize().z()
     });
 }
@@ -386,11 +386,11 @@ fn autodiff_vec3_cross_x() {
         let ax = inputs[0];
         let ay = inputs[1];
         let az = inputs[2];
-        let a = def(make_float3(ax, ay, az));
+        let a = def(Float3::expr(ax, ay, az));
         let bx = inputs[3];
         let by = inputs[4];
         let bz = inputs[5];
-        let b = def(make_float3(bx, by, bz));
+        let b = def(Float3::expr(bx, by, bz));
         let v = def(a.cross(*b));
         *v.x()
     });
@@ -401,11 +401,11 @@ fn autodiff_vec3_cross_y() {
         let ax = inputs[0];
         let ay = inputs[1];
         let az = inputs[2];
-        let a = def(make_float3(ax, ay, az));
+        let a = def(Float3::expr(ax, ay, az));
         let bx = inputs[3];
         let by = inputs[4];
         let bz = inputs[5];
-        let b = def(make_float3(bx, by, bz));
+        let b = def(Float3::expr(bx, by, bz));
         let v = def(a.cross(*b));
         *v.x()
     });
@@ -417,11 +417,11 @@ fn autodiff_vec3_cross_z() {
         let ax = inputs[0];
         let ay = inputs[1];
         let az = inputs[2];
-        let a = make_float3(ax, ay, az);
+        let a = Float3::expr(ax, ay, az);
         let bx = inputs[3];
         let by = inputs[4];
         let bz = inputs[5];
-        let b = make_float3(bx, by, bz);
+        let b = Float3::expr(bx, by, bz);
         let v = a.cross(b);
         v.z()
     });
@@ -432,11 +432,11 @@ fn autodiff_vec3_distance() {
         let ax = inputs[0];
         let ay = inputs[1];
         let az = inputs[2];
-        let a = make_float3(ax, ay, az);
+        let a = Float3::expr(ax, ay, az);
         let bx = inputs[3];
         let by = inputs[4];
         let bz = inputs[5];
-        let b = make_float3(bx, by, bz);
+        let b = Float3::expr(bx, by, bz);
         a.distance(b)
     });
 }
@@ -446,7 +446,7 @@ fn autodiff_vec3_replace() {
         let ax = inputs[0];
         let ay = inputs[1];
         let az = inputs[2];
-        let a = make_float3(ax, ay, az);
+        let a = Float3::expr(ax, ay, az);
         let b = inputs[3];
         let c = a.set_y(b);
         a.dot(c)
@@ -458,19 +458,19 @@ fn autodiff_matmul() {
         let ax = inputs[0];
         let ay = inputs[1];
         let az = inputs[2];
-        let a = make_float3(ax, ay, az);
+        let a = Float3::expr(ax, ay, az);
         let bx = inputs[0 + 3];
         let by = inputs[1 + 3];
         let bz = inputs[2 + 3];
-        let b = make_float3(bx, by, bz);
+        let b = Float3::expr(bx, by, bz);
         let cx = inputs[0 + 6];
         let cy = inputs[1 + 6];
         let cz = inputs[2 + 6];
-        let c = make_float3(cx, cy, cz);
+        let c = Float3::expr(cx, cy, cz);
         let dx = inputs[0 + 9];
         let dy = inputs[1 + 9];
         let dz = inputs[2 + 9];
-        let d = make_float3(dx, dy, dz);
+        let d = Float3::expr(dx, dy, dz);
         let m = Mat3Expr::new(a, b, c);
         let o = m * d;
         o.x()
@@ -482,19 +482,19 @@ fn autodiff_matmul_transpose() {
         let ax = inputs[0];
         let ay = inputs[1];
         let az = inputs[2];
-        let a = make_float3(ax, ay, az);
+        let a = Float3::expr(ax, ay, az);
         let bx = inputs[0 + 3];
         let by = inputs[1 + 3];
         let bz = inputs[2 + 3];
-        let b = make_float3(bx, by, bz);
+        let b = Float3::expr(bx, by, bz);
         let cx = inputs[0 + 6];
         let cy = inputs[1 + 6];
         let cz = inputs[2 + 6];
-        let c = make_float3(cx, cy, cz);
+        let c = Float3::expr(cx, cy, cz);
         let dx = inputs[0 + 9];
         let dy = inputs[1 + 9];
         let dz = inputs[2 + 9];
-        let d = make_float3(dx, dy, dz);
+        let d = Float3::expr(dx, dy, dz);
         let m = Mat3Expr::new(a, b, c);
         let o = m.transpose() * d;
         o.y()
@@ -506,19 +506,19 @@ fn autodiff_matmul_2() {
         let ax = inputs[0];
         let ay = inputs[1];
         let az = inputs[2];
-        let a = make_float3(ax, ay, az);
+        let a = Float3::expr(ax, ay, az);
         let bx = inputs[0 + 3];
         let by = inputs[1 + 3];
         let bz = inputs[2 + 3];
-        let b = make_float3(bx, by, bz);
+        let b = Float3::expr(bx, by, bz);
         let cx = inputs[0 + 6];
         let cy = inputs[1 + 6];
         let cz = inputs[2 + 6];
-        let c = make_float3(cx, cy, cz);
+        let c = Float3::expr(cx, cy, cz);
         let dx = inputs[0 + 9];
         let dy = inputs[1 + 9];
         let dz = inputs[2 + 9];
-        let d = make_float3(dx, dy, dz);
+        let d = Float3::expr(dx, dy, dz);
         let m = Mat3Expr::new(a, b, c);
         let o = m * m * d;
         o.z()
@@ -530,19 +530,19 @@ fn autodiff_matmul_4() {
         let ax = inputs[0];
         let ay = inputs[1];
         let az = inputs[2];
-        let a = make_float3(ax, ay, az);
+        let a = Float3::expr(ax, ay, az);
         let bx = inputs[0 + 3];
         let by = inputs[1 + 3];
         let bz = inputs[2 + 3];
-        let b = make_float3(bx, by, bz);
+        let b = Float3::expr(bx, by, bz);
         let cx = inputs[0 + 6];
         let cy = inputs[1 + 6];
         let cz = inputs[2 + 6];
-        let c = make_float3(cx, cy, cz);
+        let c = Float3::expr(cx, cy, cz);
         let dx = inputs[0 + 9];
         let dy = inputs[1 + 9];
         let dz = inputs[2 + 9];
-        let d = make_float3(dx, dy, dz);
+        let d = Float3::expr(dx, dy, dz);
         let m = Mat3Expr::new(a, b, c);
         let o = (m * m) * d;
         o.z()
@@ -554,19 +554,19 @@ fn autodiff_matmul_5() {
         let ax = inputs[0];
         let ay = inputs[1];
         let az = inputs[2];
-        let a = make_float3(ax, ay, az);
+        let a = Float3::expr(ax, ay, az);
         let bx = inputs[0 + 3];
         let by = inputs[1 + 3];
         let bz = inputs[2 + 3];
-        let b = make_float3(bx, by, bz);
+        let b = Float3::expr(bx, by, bz);
         let cx = inputs[0 + 6];
         let cy = inputs[1 + 6];
         let cz = inputs[2 + 6];
-        let c = make_float3(cx, cy, cz);
+        let c = Float3::expr(cx, cy, cz);
         let dx = inputs[0 + 9];
         let dy = inputs[1 + 9];
         let dz = inputs[2 + 9];
-        let d = make_float3(dx, dy, dz);
+        let d = Float3::expr(dx, dy, dz);
         let m = Mat3Expr::new(a, b, c);
         let o = m.comp_mul(m) * d;
         o.z()
@@ -578,15 +578,15 @@ fn autodiff_mat_det() {
         let ax = inputs[0];
         let ay = inputs[1];
         let az = inputs[2];
-        let a = make_float3(ax, ay, az);
+        let a = Float3::expr(ax, ay, az);
         let bx = inputs[0 + 3];
         let by = inputs[1 + 3];
         let bz = inputs[2 + 3];
-        let b = make_float3(bx, by, bz);
+        let b = Float3::expr(bx, by, bz);
         let cx = inputs[0 + 6];
         let cy = inputs[1 + 6];
         let cz = inputs[2 + 6];
-        let c = make_float3(cx, cy, cz);
+        let c = Float3::expr(cx, cy, cz);
         let m = Mat3Expr::new(a, b, c);
         m.determinant()
     });
@@ -598,7 +598,7 @@ fn autodiff_mat_det() {
 //         let x = inputs[0];
 //         let y = inputs[1];
 //         let z = inputs[2];
-//         let v = make_float3(x, y, z);
+//         let v = Float3::expr(x, y, z);
 //         v.reduce_min()
 //     });
 // }
@@ -610,7 +610,7 @@ fn autodiff_mat_det() {
 //         let x = inputs[0];
 //         let y = inputs[1];
 //         let z = inputs[2];
-//         let v = make_float3(x, y, z);
+//         let v = Float3::expr(x, y, z);
 //         v.reduce_max()
 //     });
 // }
@@ -990,7 +990,7 @@ fn autodiff_if_phi4() {
         autodiff(|| {
             requires_grad(x);
             requires_grad(y);
-            consts.store(make_float3(2.0, 3.0, 4.0));
+            consts.store(Float3::expr(2.0, 3.0, 4.0));
             let const_two = consts.x();
             let const_three = consts.y();
             let const_four = consts.z();

--- a/luisa_compute/tests/misc.rs
+++ b/luisa_compute/tests/misc.rs
@@ -91,7 +91,7 @@ fn callable() {
             v.store(v.load() + 1);
         },
     );
-    let add = device.create_callable::<fn(Expr<u32>, Expr<u32>)->Expr<u32>>(&|a, b| a + b);
+    let add = device.create_callable::<fn(Expr<u32>, Expr<u32>) -> Expr<u32>>(&|a, b| a + b);
     let x = device.create_buffer::<u32>(1024);
     let y = device.create_buffer::<u32>(1024);
     let z = device.create_buffer::<u32>(1024);
@@ -698,7 +698,7 @@ fn byte_buffer() {
             let v1 = def(buf.read::<Big>(i1));
             let v2 = def(buf.read::<i32>(i2));
             let v3 = def(buf.read::<f32>(i3));
-            *v0.get_mut() = make_float3(1.0, 2.0, 3.0);
+            *v0.get_mut() = Float3::expr(1.0, 2.0, 3.0);
             for_range(0u32..32u32, |i| {
                 v1.a().write(i, i.float() * 2.0);
             });
@@ -715,7 +715,11 @@ fn byte_buffer() {
         ($t:ty, $offset:expr) => {{
             let s = std::mem::size_of::<$t>();
             let bytes = &data[$offset..$offset + s];
-            let v = unsafe { std::mem::transmute_copy::<[u8; {std::mem::size_of::<$t>()}], $t>(bytes.try_into().unwrap()) };
+            let v = unsafe {
+                std::mem::transmute_copy::<[u8; { std::mem::size_of::<$t>() }], $t>(
+                    bytes.try_into().unwrap(),
+                )
+            };
             v
         }};
     }
@@ -723,7 +727,7 @@ fn byte_buffer() {
     let v1 = pop!(Big, i1);
     let v2 = pop!(i32, i2);
     let v3 = pop!(f32, i3);
-    assert_eq!(v0, Float3::new(1.0,2.0,3.0));
+    assert_eq!(v0, Float3::new(1.0, 2.0, 3.0));
     assert_eq!(v2, 1);
     assert_eq!(v3, 2.0);
     for i in 0..32 {
@@ -759,7 +763,7 @@ fn bindless_byte_buffer() {
     let i2 = push!(i32, 0i32);
     let i3 = push!(f32, 1f32);
     device
-        .create_kernel::<fn(ByteBuffer)>(&|out:ByteBufferVar| {
+        .create_kernel::<fn(ByteBuffer)>(&|out: ByteBufferVar| {
             let heap = heap.var();
             let buf = heap.byte_address_buffer(0);
             let i0 = i0 as u64;
@@ -770,7 +774,7 @@ fn bindless_byte_buffer() {
             let v1 = def(buf.read::<Big>(i1));
             let v2 = def(buf.read::<i32>(i2));
             let v3 = def(buf.read::<f32>(i3));
-            *v0.get_mut() = make_float3(1.0, 2.0, 3.0);
+            *v0.get_mut() = Float3::expr(1.0, 2.0, 3.0);
             for_range(0u32..32u32, |i| {
                 v1.a().write(i, i.float() * 2.0);
             });
@@ -787,7 +791,11 @@ fn bindless_byte_buffer() {
         ($t:ty, $offset:expr) => {{
             let s = std::mem::size_of::<$t>();
             let bytes = &data[$offset..$offset + s];
-            let v = unsafe { std::mem::transmute_copy::<[u8; {std::mem::size_of::<$t>()}], $t>(bytes.try_into().unwrap()) };
+            let v = unsafe {
+                std::mem::transmute_copy::<[u8; { std::mem::size_of::<$t>() }], $t>(
+                    bytes.try_into().unwrap(),
+                )
+            };
             v
         }};
     }
@@ -795,7 +803,7 @@ fn bindless_byte_buffer() {
     let v1 = pop!(Big, i1);
     let v2 = pop!(i32, i2);
     let v3 = pop!(f32, i3);
-    assert_eq!(v0, Float3::new(1.0,2.0,3.0));
+    assert_eq!(v0, Float3::new(1.0, 2.0, 3.0));
     assert_eq!(v2, 1);
     assert_eq!(v3, 2.0);
     for i in 0..32 {


### PR DESCRIPTION
**Summary of Changes:**

This pull request changes all use of `make_xxxxN(...)` with `XxxxN::expr(...)`.

**Why?**

The primary reason for this is that the `make_float4` type functions are rather deceptive - the direct reading would imply that it'd make a `Float4`, but it actually makes a `Float4Expr`. Additionally, it was rather inconvenient to discover how to create `Float4Expr`s out of normal values, as the `Float4Expr::new` didn't support taking `Into<F32>` types. Replacing these functions with `Float4::expr` functions fixes this issue, as well as decreases number of imports necessary (if not using a glob `luisa::*` import) and namespace pollution, and also cleans up the code, as the `make_xxxxN` functions had to be special-coded.

**Concerns:**

- There is still a `Float4Expr::new(` function remaining. I kept this as a way of building `Float4Expr`s without having a possibility for side effects due to the `Into` type might be useful occasionally, but removing it might be helpful.
- This is a breaking change, and will require refactoring of the renderer dependent on this.
