### PR TITLE
Unbreak the loop macro since rust doesn't scope macros in modules.

### DIFF
--- a/luisa_compute/src/lang/mod.rs
+++ b/luisa_compute/src/lang/mod.rs
@@ -2614,7 +2614,7 @@ macro_rules! while_ {
 #[macro_export]
 macro_rules! loop_ {
     ($body:block) => {
-        $crate::lang::while_!(const_(true), $body)
+        $crate::while_!(const_(true), $body)
     };
 }
 pub trait ForLoopRange {


### PR DESCRIPTION
@Mike-Leo-Smith Accidentally broke this in #6, so here's the fix.