### PR TITLE
Made ops not use manual impls; added assignment operators (using *x+=a syntax); vector index.

### DIFF
--- a/luisa_compute/src/lang.rs
+++ b/luisa_compute/src/lang.rs
@@ -49,13 +49,16 @@ pub(crate) trait CallFuncTrait {
 }
 impl CallFuncTrait for Func {
     fn call<T: Value, S: Value>(self, x: Expr<T>) -> Expr<S> {
+        let x = x.node();
         Expr::<S>::from_node(__current_scope(|b| {
-            b.call(self, &[x.node()], <S as TypeOf>::type_())
+            b.call(self, &[x], <S as TypeOf>::type_())
         }))
     }
     fn call2<T: Value, S: Value, U: Value>(self, x: Expr<T>, y: Expr<S>) -> Expr<U> {
+        let x = x.node();
+        let y = y.node();
         Expr::<U>::from_node(__current_scope(|b| {
-            b.call(self, &[x.node(), y.node()], <U as TypeOf>::type_())
+            b.call(self, &[x, y], <U as TypeOf>::type_())
         }))
     }
     fn call3<T: Value, S: Value, U: Value, V: Value>(
@@ -64,27 +67,32 @@ impl CallFuncTrait for Func {
         y: Expr<S>,
         z: Expr<U>,
     ) -> Expr<V> {
+        let x = x.node();
+        let y = y.node();
+        let z = z.node();
         Expr::<V>::from_node(__current_scope(|b| {
-            b.call(
-                self,
-                &[x.node(), y.node(), z.node()],
-                <V as TypeOf>::type_(),
-            )
+            b.call(self, &[x, y, z], <V as TypeOf>::type_())
         }))
     }
     fn call_void<T: Value>(self, x: Expr<T>) {
+        let x = x.node();
         __current_scope(|b| {
-            b.call(self, &[x.node()], Type::void());
+            b.call(self, &[x], Type::void());
         });
     }
     fn call2_void<T: Value, S: Value>(self, x: Expr<T>, y: Expr<S>) {
+        let x = x.node();
+        let y = y.node();
         __current_scope(|b| {
-            b.call(self, &[x.node(), y.node()], Type::void());
+            b.call(self, &[x, y], Type::void());
         });
     }
     fn call3_void<T: Value, S: Value, U: Value>(self, x: Expr<T>, y: Expr<S>, z: Expr<U>) {
+        let x = x.node();
+        let y = y.node();
+        let z = z.node();
         __current_scope(|b| {
-            b.call(self, &[x.node(), y.node(), z.node()], Type::void());
+            b.call(self, &[x, y, z], Type::void());
         });
     }
 }

--- a/luisa_compute/src/lang/ops.rs
+++ b/luisa_compute/src/lang/ops.rs
@@ -4,10 +4,11 @@ use std::ops::*;
 use super::types::core::{Floating, Integral, Numeric, Primitive, Signed};
 use super::types::vector::{VectorAlign, VectorElement};
 
-pub mod impls;
-pub mod spread;
-pub mod traits;
+mod impls;
+mod spread;
+mod traits;
 
+pub use spread::*;
 pub use traits::*;
 
 pub unsafe trait CastFrom<T: Primitive>: Primitive {}

--- a/luisa_compute/src/lang/ops/impls.rs
+++ b/luisa_compute/src/lang/ops/impls.rs
@@ -74,18 +74,22 @@ macro_rules! impl_ops_trait {
         }
     }
 }
-impl<X: Linear> MinMaxExpr for Expr<X>
-where
-    X::Scalar: Numeric,
-{
-    type Output = Self;
-    fn max(self, other: Self) -> Self {
-        Func::Max.call2(self, other)
-    }
-    fn min(self, other: Self) -> Self {
-        Func::Min.call2(self, other)
+macro_rules! impl_simple_binop {
+    (
+        [$($bounds:tt)*] $TraitExpr:ident [$TraitThis:ident] for $T:ty where [$($where:tt)*]: $fn:ident [$fn_this:ident] ($func:ident)
+    ) => {
+        impl_ops_trait!([$($bounds)*] $TraitExpr [$TraitThis] for $T where [$($where)*] {
+            fn $fn[$fn_this](self, other) { Func::$func.call2(self, other) }
+        });
     }
 }
+
+impl_ops_trait!([X: Linear] MinMaxExpr[MinMaxThis] for Expr<X> where [X::Scalar: Numeric] {
+    type Output = Expr<X::WithScalar<X::Scalar>>;
+
+    fn max_expr[_max_expr](self, other) { Func::Max.call2(self, other) }
+    fn min_expr[_min_expr](self, other) { Func::Min.call2(self, other) }
+});
 
 impl_ops_trait!([X: Linear] ClampExpr[ClampThis] for Expr<X> where [X::Scalar: Numeric] {
     fn clamp[_clamp](self, min, max) { Func::Clamp.call3(self, min, max) }
@@ -116,97 +120,16 @@ impl_ops_trait!([X: Linear] CmpExpr[CmpThis] for Expr<X> where [X::Scalar: Numer
     fn ge[_ge](self, other) { Func::Ge.call2(self, other) }
 });
 
-impl<X: Linear> Add for Expr<X>
-where
-    X::Scalar: Numeric,
-{
-    type Output = Self;
-    fn add(self, other: Self) -> Self {
-        Func::Add.call2(self, other)
-    }
-}
-impl<X: Linear> Sub for Expr<X>
-where
-    X::Scalar: Numeric,
-{
-    type Output = Self;
-    fn sub(self, other: Self) -> Self {
-        Func::Sub.call2(self, other)
-    }
-}
-impl<X: Linear> Mul for Expr<X>
-where
-    X::Scalar: Numeric,
-{
-    type Output = Self;
-    fn mul(self, other: Self) -> Self {
-        Func::Mul.call2(self, other)
-    }
-}
-impl<X: Linear> Div for Expr<X>
-where
-    X::Scalar: Numeric,
-{
-    type Output = Self;
-    fn div(self, other: Self) -> Self {
-        Func::Div.call2(self, other)
-    }
-}
-impl<X: Linear> Rem for Expr<X>
-where
-    X::Scalar: Numeric,
-{
-    type Output = Self;
-    fn rem(self, other: Self) -> Self {
-        Func::Rem.call2(self, other)
-    }
-}
-
-impl<X: Linear> BitAnd for Expr<X>
-where
-    X::Scalar: Integral,
-{
-    type Output = Self;
-    fn bitand(self, other: Self) -> Self {
-        Func::BitAnd.call2(self, other)
-    }
-}
-impl<X: Linear> BitOr for Expr<X>
-where
-    X::Scalar: Integral,
-{
-    type Output = Self;
-    fn bitor(self, other: Self) -> Self {
-        Func::BitOr.call2(self, other)
-    }
-}
-impl<X: Linear> BitXor for Expr<X>
-where
-    X::Scalar: Integral,
-{
-    type Output = Self;
-    fn bitxor(self, other: Self) -> Self {
-        Func::BitXor.call2(self, other)
-    }
-}
-impl<X: Linear> Shl for Expr<X>
-where
-    X::Scalar: Integral,
-{
-    type Output = Self;
-    fn shl(self, other: Self) -> Self {
-        Func::Shl.call2(self, other)
-    }
-}
-impl<X: Linear> Shr for Expr<X>
-where
-    X::Scalar: Integral,
-{
-    type Output = Self;
-    fn shr(self, other: Self) -> Self {
-        Func::Shr.call2(self, other)
-    }
-}
+impl_simple_binop!([X: Linear] AddExpr[AddThis] for Expr<X> where [X::Scalar: Numeric]: add[_add](Add));
+impl_simple_binop!([X: Linear] SubExpr[SubThis] for Expr<X> where [X::Scalar: Numeric]: sub[_sub](Sub));
+impl_simple_binop!([X: Linear] MulExpr[MulThis] for Expr<X> where [X::Scalar: Numeric]: mul[_mul](Mul));
+impl_simple_binop!([X: Linear] DivExpr[DivThis] for Expr<X> where [X::Scalar: Numeric]: div[_div](Div));
+impl_simple_binop!([X: Linear] RemExpr[RemThis] for Expr<X> where [X::Scalar: Numeric]: rem[_rem](Rem));
+impl_simple_binop!([X: Linear] BitAndExpr[BitAndThis] for Expr<X> where [X::Scalar: Integral]: bitand[_bitand](BitAnd));
+impl_simple_binop!([X: Linear] BitOrExpr[BitOrThis] for Expr<X> where [X::Scalar: Integral]: bitor[_bitor](BitOr));
+impl_simple_binop!([X: Linear] BitXorExpr[BitXorThis] for Expr<X> where [X::Scalar: Integral]: bitxor[_bitxor](BitXor));
+impl_simple_binop!([X: Linear] ShlExpr[ShlThis] for Expr<X> where [X::Scalar: Integral]: shl[_shl](Shl));
+impl_simple_binop!([X: Linear] ShrExpr[ShrThis] for Expr<X> where [X::Scalar: Integral]: shr[_shr](Shr));
 
 impl<X: Linear> Neg for Expr<X>
 where
@@ -280,7 +203,7 @@ where
         log10 => Log10
     }
     fn is_finite(&self) -> Self::Bool {
-        !self.is_infinite() & !self.is_nan()
+        !self.is_infinite().bitand(!self.is_nan())
     }
     fn is_infinite(&self) -> Self::Bool {
         Func::IsInf.call(self.clone())
@@ -289,10 +212,10 @@ where
         Func::IsNan.call(self.clone())
     }
     fn sqr(&self) -> Self {
-        self.clone() * self.clone()
+        self.clone().mul(self.clone())
     }
     fn cube(&self) -> Self {
-        self.clone() * self.clone() * self.clone()
+        self.clone().mul(self.clone()).mul(self.clone())
     }
     fn recip(&self) -> Self {
         todo!()
@@ -323,7 +246,7 @@ impl_ops_trait!([X: Linear] FloatArcTan2Expr[FloatArcTan2This] for Expr<X> where
 });
 
 impl_ops_trait!([X: Linear] FloatLogExpr[FloatLogThis] for Expr<X> where [X::Scalar: Floating] {
-    fn log[_log](self, base) { self.ln() / base.ln()}
+    fn log[_log](self, base) { self.ln().div(base.ln()) }
 });
 
 impl_ops_trait!([X: Linear] FloatPowfExpr[FloatPowfThis] for Expr<X> where [X::Scalar: Floating] {
@@ -415,25 +338,25 @@ impl LoopMaybeExpr for Expr<bool> {
     }
 }
 
-impl LazyBoolMaybeExpr for bool {
+impl LazyBoolMaybeExpr<bool, ValueType> for bool {
     type Bool = bool;
-    fn __and(self, other: impl FnOnce() -> bool) -> bool {
+    fn and(self, other: impl FnOnce() -> bool) -> bool {
         self && other()
     }
-    fn __or(self, other: impl FnOnce() -> bool) -> bool {
+    fn or(self, other: impl FnOnce() -> bool) -> bool {
         self || other()
     }
 }
-impl LazyBoolMaybeExpr<Expr<bool>> for bool {
+impl LazyBoolMaybeExpr<Expr<bool>, ExprType> for bool {
     type Bool = Expr<bool>;
-    fn __and(self, other: impl FnOnce() -> Expr<bool>) -> Self::Bool {
+    fn and(self, other: impl FnOnce() -> Expr<bool>) -> Self::Bool {
         if self {
             other()
         } else {
             false.expr()
         }
     }
-    fn __or(self, other: impl FnOnce() -> Expr<bool>) -> Self::Bool {
+    fn or(self, other: impl FnOnce() -> Expr<bool>) -> Self::Bool {
         if self {
             true.expr()
         } else {
@@ -441,16 +364,16 @@ impl LazyBoolMaybeExpr<Expr<bool>> for bool {
         }
     }
 }
-impl LazyBoolMaybeExpr<bool> for Expr<bool> {
+impl LazyBoolMaybeExpr<bool, ExprType> for Expr<bool> {
     type Bool = Expr<bool>;
-    fn __and(self, other: impl FnOnce() -> bool) -> Self::Bool {
+    fn and(self, other: impl FnOnce() -> bool) -> Self::Bool {
         if other() {
             self
         } else {
             false.expr()
         }
     }
-    fn __or(self, other: impl FnOnce() -> bool) -> Self::Bool {
+    fn or(self, other: impl FnOnce() -> bool) -> Self::Bool {
         if other() {
             true.expr()
         } else {
@@ -458,74 +381,12 @@ impl LazyBoolMaybeExpr<bool> for Expr<bool> {
         }
     }
 }
-impl LazyBoolMaybeExpr for Expr<bool> {
+impl LazyBoolMaybeExpr<Expr<bool>, ExprType> for Expr<bool> {
     type Bool = Expr<bool>;
-    fn __and(self, other: impl FnOnce() -> Expr<bool>) -> Self::Bool {
+    fn and(self, other: impl FnOnce() -> Expr<bool>) -> Self::Bool {
         crate::lang::control_flow::if_then_else(self, other, || false.expr())
     }
-    fn __or(self, other: impl FnOnce() -> Expr<bool>) -> Self::Bool {
+    fn or(self, other: impl FnOnce() -> Expr<bool>) -> Self::Bool {
         crate::lang::control_flow::if_then_else(self, || true.expr(), other)
-    }
-}
-
-impl<T, S> EqMaybeExpr<S, ExprType> for T
-where
-    T: EqExpr<S>,
-{
-    type Bool = <T as EqExpr<S>>::Output;
-    fn __eq(self, other: S) -> Self::Bool {
-        self.eq(other)
-    }
-    fn __ne(self, other: S) -> Self::Bool {
-        self.ne(other)
-    }
-}
-impl<T, S> EqMaybeExpr<S, ValueType> for T
-where
-    T: PartialEq<S>,
-{
-    type Bool = bool;
-    fn __eq(self, other: S) -> Self::Bool {
-        self == other
-    }
-    fn __ne(self, other: S) -> Self::Bool {
-        self != other
-    }
-}
-
-impl<T, S> CmpMaybeExpr<S, ExprType> for T
-where
-    T: CmpExpr<S>,
-{
-    type Bool = <T as CmpExpr<S>>::Output;
-    fn __lt(self, other: S) -> Self::Bool {
-        self.lt(other)
-    }
-    fn __le(self, other: S) -> Self::Bool {
-        self.le(other)
-    }
-    fn __gt(self, other: S) -> Self::Bool {
-        self.gt(other)
-    }
-    fn __ge(self, other: S) -> Self::Bool {
-        self.ge(other)
-    }
-}
-impl<T, S> CmpMaybeExpr<S, ValueType> for T
-where
-    T: PartialOrd<S>,
-{
-    type Bool = bool;
-    fn __lt(self, other: S) -> Self::Bool {
-        self < other
-    }
-    fn __le(self, other: S) -> Self::Bool {
-        self <= other
-    }
-    fn __gt(self, other: S) -> Self::Bool {
-        self > other
-    }
-    fn __ge(self, other: S) -> Self::Bool {
-        self >= other
     }
 }

--- a/luisa_compute/src/lang/ops/impls.rs
+++ b/luisa_compute/src/lang/ops/impls.rs
@@ -5,7 +5,11 @@ impl<X: Linear> Expr<X> {
     where
         Y::Scalar: CastFrom<X::Scalar>,
     {
-        assert_eq!(X::N, Y::N, "Cannot cast between scalars/vectors of different dimensions.");
+        assert_eq!(
+            X::N,
+            Y::N,
+            "Cannot cast between scalars/vectors of different dimensions."
+        );
         Func::Cast.call(self)
     }
     pub fn cast<S: VectorElement>(self) -> Expr<X::WithScalar<S>>

--- a/luisa_compute/src/lang/ops/impls.rs
+++ b/luisa_compute/src/lang/ops/impls.rs
@@ -37,15 +37,6 @@ macro_rules! impl_ops_trait {
                 }
             )*
         }
-        impl<$($bounds)*> $TraitExpr for $T where $($where)* {
-            type Output = Self;
-
-            $(
-                fn $fn($sl, $($arg: Self),*) -> Self {
-                    <$T as $TraitThis>::$fn_this($sl, $($arg),*)
-                }
-            )*
-        }
     };
     (
         [$($bounds:tt)*] $TraitExpr:ident [$TraitThis:ident] for $T:ty where [$($where:tt)*] {
@@ -60,15 +51,6 @@ macro_rules! impl_ops_trait {
             $(
                 fn $fn_this($sl, $($arg: Self),*) -> Self::Output {
                    $body
-                }
-            )*
-        }
-        impl<$($bounds)*> $TraitExpr for $T where $($where)* {
-            type Output = $Output;
-
-            $(
-                fn $fn($sl, $($arg: Self),*) -> Self::Output {
-                    <$T as $TraitThis>::$fn_this($sl, $($arg),*)
                 }
             )*
         }

--- a/luisa_compute/src/lang/ops/spread.rs
+++ b/luisa_compute/src/lang/ops/spread.rs
@@ -43,10 +43,9 @@ macro_rules! impl_spread {
 
 macro_rules! call_linear_fn_spread {
     ($f:ident [$($bounds:tt)*]($T:ty)) => {
-        // The T to other value impls mess up the `Ord` impls.
-        $f!(@sym [$($bounds)*] Expr<$T>: |x| x, $T: |x| x.expr() => Expr<$T>);
+        $f!([$($bounds)*] $T: |x| x.expr(), Expr<$T>: |x| x => Expr<$T>);
         $f!(['a, $($bounds)*] &'a $T: |x| x.expr(), Expr<$T>: |x| x => Expr<$T>);
-        $f!(@sym ['b, $($bounds)*] &'b Expr<$T>: |x| x.clone(), $T: |x| x.expr() => Expr<$T>);
+        $f!(['b, $($bounds)*] $T: |x| x.expr(), &'b Expr<$T>: |x| x.clone() => Expr<$T>);
         $f!(['a, 'b, $($bounds)*] &'a $T: |x| x.expr(), &'b Expr<$T>: |x| x.clone() => Expr<$T>);
 
         $f!(['b, $($bounds)*] Expr<$T>: |x| x, &'b Expr<$T>: |x| x.clone() => Expr<$T>);
@@ -55,10 +54,10 @@ macro_rules! call_linear_fn_spread {
         $f!(@sym [$($bounds)*] Var<$T>: |x| x.load(), Var<$T>: |x| x.load() => Expr<$T>);
         $f!(@sym ['a, 'b, $($bounds)*] &'a Var<$T>: |x| x.load(), &'b Var<$T>: |x| x.load() => Expr<$T>);
 
-        $f!(@sym [$($bounds)*] Var<$T>: |x| x.load(), $T: |x| x.expr() => Expr<$T>);
+        $f!([$($bounds)*] $T: |x| x.expr(), Var<$T>: |x| x.load() => Expr<$T>);
         $f!(['a, $($bounds)*] &'a $T: |x| x.expr(), Var<$T>: |x| x.load() => Expr<$T>);
-        $f!(@sym ['b, $($bounds)*] &'b Var<$T>: |x| x.load(), $T: |x| x.expr() => Expr<$T>);
-         $f!(['a, 'b, $($bounds)*] &'a $T: |x| x.expr(), &'b Var<$T>: |x| x.load() => Expr<$T>);
+        $f!(['b, $($bounds)*] $T: |x| x.expr(), &'b Var<$T>: |x| x.load() => Expr<$T>);
+        $f!(['a, 'b, $($bounds)*] &'a $T: |x| x.expr(), &'b Var<$T>: |x| x.load() => Expr<$T>);
 
         $f!(['a, $($bounds)*] &'a Expr<$T>: |x| x.clone(), Var<$T>: |x| x.load() => Expr<$T>);
         $f!(['a, 'b, $($bounds)*] &'a Expr<$T>: |x| x.clone(), &'b Var<$T>: |x| x.load() => Expr<$T>);
@@ -74,11 +73,11 @@ call_linear_fn_spread!(impl_spread[T]);
 
 macro_rules! call_vector_fn_spread {
     ($f:ident [$($bounds:tt)*]($N:tt, $T:ty) $Vt:ty, $Vsplat:path) => {
-        $f!(@sym [$($bounds)*] Expr<$Vt>: |x| x, $T: |x| $Vsplat(x) => Expr<$Vt>);
+        $f!([$($bounds)*] $T: |x| $Vsplat(x), Expr<$Vt>: |x| x => Expr<$Vt>);
         $f!(['a, $($bounds)*] &'a $T: |x| $Vsplat(*x), Expr<$Vt>: |x| x => Expr<$Vt>);
         $f!([$($bounds)*] Expr<$T>: |x| $Vsplat(x), Expr<$Vt>: |x| x => Expr<$Vt>);
         $f!(['a, $($bounds)*] &'a Expr<$T>: |x| $Vsplat(x), Expr<$Vt>: |x| x => Expr<$Vt>);
-        $f!(@sym ['b, $($bounds)*] &'b Expr<$Vt>: |x| x.clone(), $T: |x| $Vsplat(x) => Expr<$Vt>);
+        $f!(['b, $($bounds)*] $T: |x| $Vsplat(x), &'b Expr<$Vt>: |x| x.clone() => Expr<$Vt>);
         $f!(['a, 'b, $($bounds)*] &'a $T: |x| $Vsplat(*x), &'b Expr<$Vt>: |x| x.clone() => Expr<$Vt>);
         $f!(['b, $($bounds)*] Expr<$T>: |x| $Vsplat(x), &'b Expr<$Vt>: |x| x.clone() => Expr<$Vt>);
         $f!(['a, 'b, $($bounds)*] &'a Expr<$T>: |x| $Vsplat(x), &'b Expr<$Vt>: |x| x.clone() => Expr<$Vt>);
@@ -88,11 +87,11 @@ macro_rules! call_vector_fn_spread {
         $f!(['b, $($bounds)*] Expr<$T>: |x| $Vsplat(x), &'b $Vt: |x| x.expr() => Expr<$Vt>);
         $f!(['a, 'b, $($bounds)*] &'a Expr<$T>: |x| $Vsplat(x), &'b $Vt: |x| x.expr() => Expr<$Vt>);
 
-        $f!(@sym [$($bounds)*] Var<$Vt>: |x| x.load(), $T: |x| $Vsplat(x) => Expr<$Vt>);
+        $f!([$($bounds)*] $T: |x| $Vsplat(x), Var<$Vt>: |x| x.load() => Expr<$Vt>);
         $f!(['a, $($bounds)*] &'a $T: |x| $Vsplat(*x), Var<$Vt>: |x| x.load() => Expr<$Vt>);
         $f!([$($bounds)*] Expr<$T>: |x| $Vsplat(x), Var<$Vt>: |x| x.load() => Expr<$Vt>);
         $f!(['a, $($bounds)*] &'a Expr<$T>: |x| $Vsplat(x), Var<$Vt>: |x| x.load() => Expr<$Vt>);
-        $f!(@sym ['b, $($bounds)*] &'b Var<$Vt>: |x| x.load(), $T: |x| $Vsplat(x) => Expr<$Vt>);
+        $f!(['b, $($bounds)*] $T: |x| $Vsplat(x), &'b Var<$Vt>: |x| x.load() => Expr<$Vt>);
         $f!(['a, 'b, $($bounds)*] &'a $T: |x| $Vsplat(*x), &'b Var<$Vt>: |x| x.load() => Expr<$Vt>);
         $f!(['b, $($bounds)*] Expr<$T>: |x| $Vsplat(x), &'b Var<$Vt>: |x| x.load() => Expr<$Vt>);
         $f!(['a, 'b, $($bounds)*] &'a Expr<$T>: |x| $Vsplat(x), &'b Var<$Vt>: |x| x.load() => Expr<$Vt>);
@@ -114,19 +113,6 @@ call_vector_fn_spread!(impl_spread[N, T]);
 
 mod trait_impls {
     use super::*;
-    impl<T, S> MinMaxExpr<S> for T
-    where
-        T: SpreadOps<S>,
-        Expr<T::Join>: MinMaxThis,
-    {
-        type Output = Expr<T::Join>;
-        fn max(self, other: S) -> Self::Output {
-            Expr::<T::Join>::_max(Self::lift_self(self), Self::lift_other(other))
-        }
-        fn min(self, other: S) -> Self::Output {
-            Expr::<T::Join>::_min(Self::lift_self(self), Self::lift_other(other))
-        }
-    }
     impl<T: Value, S, U> ClampExpr<S, U> for Expr<T>
     where
         S: SpreadOps<U, Join = T>,
@@ -263,6 +249,19 @@ macro_rules! impl_spread_op {
 
 macro_rules! impl_num_spread_single {
     ([ $($bounds:tt)* ] $T:ty, $S:ty) => {
+        // impl<$($bounds)*> MinMaxExpr<$S> for $T
+        // where
+        //     $T: SpreadOps<$S>,
+        //     Expr<<$T as SpreadOps<$S>>::Join>: MinMaxExpr,
+        // {
+        //     type Output = <Expr<<$T as SpreadOps<$S>>::Join> as MinMaxExpr>::Output;
+        //     fn max(self, other: $S) -> <Expr<<$T as SpreadOps<$S>>::Join> as MinMaxExpr>::Output {
+        //         Expr::<<$T as SpreadOps<$S>>::Join>::max(<$T as SpreadOps<$S>>::lift_self(self), <$T as SpreadOps<$S>>::lift_other(other))
+        //     }
+        //     fn min(self, other: $S) -> <Expr<<$T as SpreadOps<$S>>::Join> as MinMaxExpr>::Output {
+        //         Expr::<<$T as SpreadOps<$S>>::Join>::min(<$T as SpreadOps<$S>>::lift_self(self), <$T as SpreadOps<$S>>::lift_other(other))
+        //     }
+        // }
         impl_spread_op!( [ $($bounds)* ]: Add::add for $T, $S);
         impl_spread_op!( [ $($bounds)* ]: Sub::sub for $T, $S);
         impl_spread_op!( [ $($bounds)* ]: Mul::mul for $T, $S);
@@ -302,6 +301,9 @@ macro_rules! call_spreads {
     ($f:ident: $($T:ty),+) => {
         $(
         call_linear_fn_spread!($f []($T));
+        call_linear_fn_spread!($f [](Vector<$T, 2>));
+        call_linear_fn_spread!($f [](Vector<$T, 3>));
+        call_linear_fn_spread!($f [](Vector<$T, 4>));
         call_vector_fn_spread!($f [](2, $T));
         call_vector_fn_spread!($f [](3, $T));
         call_vector_fn_spread!($f [](4, $T));
@@ -310,20 +312,3 @@ macro_rules! call_spreads {
 }
 call_spreads!(impl_num_spread: f16, f32, f64, i8, i16, i32, i64, u8, u16, u32, u64);
 call_spreads!(impl_int_spread: bool, i8, i16, i32, i64, u8, u16, u32, u64);
-
-#[allow(dead_code)]
-mod tests {
-    use super::*;
-    fn test() {
-        let x = 10.0f32;
-        let y = Vector::<_, 2>::splat(20.0f32);
-        let x = x.expr();
-
-        let w = (&x.var()).min(&0.0_f32.expr());
-        let z = 10_f32.max(5_f32);
-        let i = 15_u32;
-        let j = z.log(10.0);
-        let _ = 1_u32.max(2_u32);
-        println!("{:?}", w);
-    }
-}

--- a/luisa_compute/src/lang/ops/spread.rs
+++ b/luisa_compute/src/lang/ops/spread.rs
@@ -46,6 +46,8 @@ macro_rules! impl_spread {
 
 macro_rules! call_linear_fn_spread {
     ($f:ident [$($bounds:tt)*]($T:ty)) => {
+        $f!(@sym [$($bounds)*] Expr<$T>: |x| x, Expr<$T>: |x| x => Expr<$T>);
+
         $f!([$($bounds)*] $T: |x| x.expr(), Expr<$T>: |x| x => Expr<$T>);
         $f!(['a, $($bounds)*] &'a $T: |x| x.expr(), Expr<$T>: |x| x => Expr<$T>);
         $f!(['b, $($bounds)*] $T: |x| x.expr(), &'b Expr<$T>: |x| x.clone() => Expr<$T>);

--- a/luisa_compute/src/lang/ops/spread.rs
+++ b/luisa_compute/src/lang/ops/spread.rs
@@ -1,5 +1,5 @@
 use crate::lang::types::core::PrimitiveVar;
-use crate::lang::types::{ExprProxy, VarProxy};
+use crate::lang::types::VarProxy;
 
 use super::*;
 use traits::*;
@@ -129,9 +129,22 @@ macro_rules! impl_simple_binop_spread {
     };
 }
 
+macro_rules! impl_var_assign {
+    ($TraitExpr:ident: $fn:ident) => {
+        impl<T: Value, S> $TraitExpr<S> for Var<T>
+        where
+            T::Var: $TraitExpr<S>,
+        {
+            fn $fn(self, other: S) {
+                <T::Var as $TraitExpr<S>>::$fn(self.deref().clone(), other);
+            }
+        }
+    };
+}
+
 macro_rules! impl_assignop_spread {
     ([$($bounds:tt)*] $TraitExpr:ident [$TraitOrigExpr:ident] for $X:ty[$V:ty]: $assign_fn:ident [$fn:ident]) => {
-        impl<_Other, $($bounds)*> $TraitExpr<_Other> for &$X
+        impl<_Other, $($bounds)*> $TraitExpr<_Other> for $X
         where
             Expr<$V>: $TraitOrigExpr,
             Expr<$V>: SpreadOps<_Other, Join = $V> + Sized,
@@ -147,6 +160,16 @@ macro_rules! impl_assignop_spread {
         }
     }
 }
+impl_var_assign!(AddAssignExpr: add_assign);
+impl_var_assign!(SubAssignExpr: sub_assign);
+impl_var_assign!(MulAssignExpr: mul_assign);
+impl_var_assign!(DivAssignExpr: div_assign);
+impl_var_assign!(RemAssignExpr: rem_assign);
+impl_var_assign!(BitAndAssignExpr: bitand_assign);
+impl_var_assign!(BitOrAssignExpr: bitor_assign);
+impl_var_assign!(BitXorAssignExpr: bitxor_assign);
+impl_var_assign!(ShlAssignExpr: shl_assign);
+impl_var_assign!(ShrAssignExpr: shr_assign);
 
 macro_rules! impl_assignops {
     ([$($bounds:tt)*] $X:ty[$V:ty]) => {

--- a/luisa_compute/src/lang/ops/traits.rs
+++ b/luisa_compute/src/lang/ops/traits.rs
@@ -1,3 +1,5 @@
+use crate::lang::types::TrackingType;
+
 use super::*;
 
 // The double trait implementation is necessary as the compiler infinite loops
@@ -47,10 +49,11 @@ macro_rules! ops_trait {
     }
 }
 
-ops_trait!(MinMaxExpr<T>[MinMaxThis] {
-    fn max[_max](self, other: T);
-    fn min[_min](self, other: T);
-});
+pub trait MinMaxExpr<T = Self> {
+    type Output;
+    fn max(self, other: T) -> Self::Output;
+    fn min(self, other: T) -> Self::Output;
+}
 
 ops_trait!(ClampExpr<A, B>[ClampThis] {
     fn clamp[_clamp](self, min: A, max: B);
@@ -175,17 +178,17 @@ pub trait LoopMaybeExpr {
 
 pub trait LazyBoolMaybeExpr<T = Self> {
     type Bool;
-    fn and(self, other: impl FnOnce() -> T) -> Self::Bool;
-    fn or(self, other: impl FnOnce() -> T) -> Self::Bool;
+    fn __and(self, other: impl FnOnce() -> T) -> Self::Bool;
+    fn __or(self, other: impl FnOnce() -> T) -> Self::Bool;
 }
 
-pub trait EqMaybeExpr<T, const EXPR: bool> {
+pub trait EqMaybeExpr<T, Ty: TrackingType> {
     type Bool;
     fn __eq(self, other: T) -> Self::Bool;
     fn __ne(self, other: T) -> Self::Bool;
 }
 
-pub trait CmpMaybeExpr<T, const EXPR: bool> {
+pub trait CmpMaybeExpr<T, Ty: TrackingType> {
     type Bool;
     fn __lt(self, other: T) -> Self::Bool;
     fn __le(self, other: T) -> Self::Bool;

--- a/luisa_compute/src/lang/ops/traits.rs
+++ b/luisa_compute/src/lang/ops/traits.rs
@@ -59,7 +59,7 @@ macro_rules! ops_trait {
                 fn $fn [$fn_this] ($self, $($arg: $S),*);
             )+
         });
-        trait $TraitMaybe<$($T,)* Ty: TrackingType> {
+        pub trait $TraitMaybe<$($T,)* Ty: TrackingType> {
             type Output;
             $(
                 fn $fn_maybe($self, $($arg: $S),*) -> Self::Output;

--- a/luisa_compute/src/lang/types.rs
+++ b/luisa_compute/src/lang/types.rs
@@ -201,6 +201,16 @@ impl<T: Value> Var<T> {
             b.local_zero_init(<T as TypeOf>::type_())
         }))
     }
+    pub fn _ref<'a>(self) -> &'a Self {
+        RECORDER.with(|r| {
+            let r = r.borrow();
+            let v: &Var<T> = r.arena.alloc(self);
+            unsafe {
+                let v: &'a Var<T> = std::mem::transmute(v);
+                v
+            }
+        })
+    }
     pub fn load(&self) -> Expr<T> {
         __current_scope(|b| {
             let nodes = self.to_vec_nodes();

--- a/luisa_compute/src/lang/types.rs
+++ b/luisa_compute/src/lang/types.rs
@@ -52,6 +52,9 @@ pub trait Value: Copy + TypeOf + 'static {
 /// exposes an [`Index`](std::ops::Index) impl.
 pub trait ExprProxy: Clone + HasExprLayout<<Self::Value as Value>::ExprData> + 'static {
     type Value: Value<Expr = Self>;
+    fn as_expr_from_proxy(&self) -> &Expr<Self::Value> {
+        unsafe { &*(self as *const Self as *const Expr<Self::Value>) }
+    }
 }
 
 /// A trait for implementing remote impls on top of an [`Var`] using [`Deref`].
@@ -63,6 +66,9 @@ pub trait VarProxy:
     Clone + HasVarLayout<<Self::Value as Value>::VarData> + Deref<Target = Expr<Self::Value>> + 'static
 {
     type Value: Value<Var = Self>;
+    fn as_var_from_proxy(&self) -> &Var<Self::Value> {
+        unsafe { &*(self as *const Self as *const Var<Self::Value>) }
+    }
 }
 /// This marker trait states that `Self` has the same layout as an [`Expr<T>`]
 /// with `T::ExprData = X`.

--- a/luisa_compute/src/lang/types.rs
+++ b/luisa_compute/src/lang/types.rs
@@ -205,6 +205,9 @@ impl<T: Value> Var<T> {
             Expr::<T>::from_nodes(&mut ret.into_iter())
         })
     }
+    pub fn store(&self, value: impl AsExpr<Value = T>) {
+        crate::lang::_store(self, &value.as_expr());
+    }
 }
 
 pub fn _deref_proxy<P: VarProxy>(proxy: &P) -> &Expr<P::Value> {
@@ -308,7 +311,7 @@ pub trait AsExpr: Tracked {
 }
 
 impl<T: Value> AsExpr for T {
-    fn as_expr(&self) -> Expr<Self::Value> {
+    fn as_expr(&self) -> Expr<T> {
         self.expr()
     }
 }

--- a/luisa_compute/src/lang/types.rs
+++ b/luisa_compute/src/lang/types.rs
@@ -212,14 +212,17 @@ impl<T: Value> Var<T> {
         })
     }
     pub fn load(&self) -> Expr<T> {
-        __current_scope(|b| {
-            let nodes = self.to_vec_nodes();
-            let mut ret = vec![];
-            for node in nodes {
-                ret.push(b.call(Func::Load, &[node], node.type_().clone()));
-            }
-            Expr::<T>::from_nodes(&mut ret.into_iter())
-        })
+        Expr::<T>::from_nodes(
+            &mut __current_scope(|b| {
+                let nodes = self.to_vec_nodes();
+                let mut ret = vec![];
+                for node in nodes {
+                    ret.push(b.call(Func::Load, &[node], node.type_().clone()));
+                }
+                ret
+            })
+            .into_iter(),
+        )
     }
     pub fn store(&self, value: impl AsExpr<Value = T>) {
         crate::lang::_store(self, &value.as_expr());

--- a/luisa_compute/src/lang/types/alignment.rs
+++ b/luisa_compute/src/lang/types/alignment.rs
@@ -1,4 +1,3 @@
-use super::*;
 use std::hash::Hash;
 
 pub trait Alignment: Default + Copy + Hash + Eq + 'static {

--- a/luisa_compute/src/lang/types/array.rs
+++ b/luisa_compute/src/lang/types/array.rs
@@ -26,7 +26,9 @@ impl<T: Value, const N: usize, X: IntoIndex> Index<X> for ArrayExpr<T, N> {
         let i = i.to_u64();
 
         // TODO: Add need_runtime_check()?
-        lc_assert!(i.lt((N as u64).expr()));
+        if need_runtime_check() {
+            lc_assert!(i.lt((N as u64).expr()));
+        }
 
         Expr::<T>::from_node(__current_scope(|b| {
             b.call(Func::ExtractElement, &[self.0.node, i.node()], T::type_())

--- a/luisa_compute/src/lang/types/vector.rs
+++ b/luisa_compute/src/lang/types/vector.rs
@@ -14,7 +14,8 @@ mod element;
 mod impls;
 pub mod swizzle;
 
-use swizzle::*;
+pub use impls::*;
+pub use swizzle::*;
 
 pub trait VectorElement: VectorAlign<2> + VectorAlign<3> + VectorAlign<4> {}
 impl<T: VectorAlign<2> + VectorAlign<3> + VectorAlign<4>> VectorElement for T {}
@@ -66,66 +67,6 @@ pub struct DoubledProxyData<X: FromNode + Copy>(X, X);
 impl<X: FromNode + Copy> FromNode for DoubledProxyData<X> {
     fn from_node(node: NodeRef) -> Self {
         Self(X::from_node(node), X::from_node(node))
-    }
-}
-
-pub trait VectorExprProxy {
-    const N: usize;
-    type T: Primitive;
-    fn node(&self) -> NodeRef;
-    fn _permute2(&self, x: u32, y: u32) -> Expr<Vec2<Self::T>>
-    where
-        Self::T: VectorAlign<2>,
-    {
-        assert!(x < Self::N as u32);
-        assert!(y < Self::N as u32);
-        let x = x.expr();
-        let y = y.expr();
-        Expr::<Vec2<Self::T>>::from_node(__current_scope(|s| {
-            s.call(
-                Func::Permute,
-                &[self.node(), x.node(), y.node()],
-                Vec2::<Self::T>::type_(),
-            )
-        }))
-    }
-    fn _permute3(&self, x: u32, y: u32, z: u32) -> Expr<Vec3<Self::T>>
-    where
-        Self::T: VectorAlign<3>,
-    {
-        assert!(x < Self::N as u32);
-        assert!(y < Self::N as u32);
-        assert!(z < Self::N as u32);
-        let x = x.expr();
-        let y = y.expr();
-        let z = z.expr();
-        Expr::<Vec3<Self::T>>::from_node(__current_scope(|s| {
-            s.call(
-                Func::Permute,
-                &[self.node(), x.node(), y.node(), z.node()],
-                Vec3::<Self::T>::type_(),
-            )
-        }))
-    }
-    fn _permute4(&self, x: u32, y: u32, z: u32, w: u32) -> Expr<Vec4<Self::T>>
-    where
-        Self::T: VectorAlign<4>,
-    {
-        assert!(x < Self::N as u32);
-        assert!(y < Self::N as u32);
-        assert!(z < Self::N as u32);
-        assert!(w < Self::N as u32);
-        let x = x.expr();
-        let y = y.expr();
-        let z = z.expr();
-        let w = w.expr();
-        Expr::<Vec4<Self::T>>::from_node(__current_scope(|s| {
-            s.call(
-                Func::Permute,
-                &[self.node(), x.node(), y.node(), z.node(), w.node()],
-                Vec4::<Self::T>::type_(),
-            )
-        }))
     }
 }
 

--- a/luisa_compute/src/lang/types/vector/impls.rs
+++ b/luisa_compute/src/lang/types/vector/impls.rs
@@ -73,3 +73,73 @@ macro_rules! impl_sized {
 impl_sized!(Vec2(2): x, y);
 impl_sized!(Vec3(3): x, y, z);
 impl_sized!(Vec4(4): x, y, z, w);
+
+pub trait VectorExprProxy {
+    const N: usize;
+    type T: Primitive;
+    fn node(&self) -> NodeRef;
+    fn _permute2(&self, x: u32, y: u32) -> Expr<Vec2<Self::T>>
+    where
+        Self::T: VectorAlign<2>,
+    {
+        assert!(x < Self::N as u32);
+        assert!(y < Self::N as u32);
+        let x = x.expr();
+        let y = y.expr();
+        Expr::<Vec2<Self::T>>::from_node(__current_scope(|s| {
+            s.call(
+                Func::Permute,
+                &[self.node(), x.node(), y.node()],
+                Vec2::<Self::T>::type_(),
+            )
+        }))
+    }
+    fn _permute3(&self, x: u32, y: u32, z: u32) -> Expr<Vec3<Self::T>>
+    where
+        Self::T: VectorAlign<3>,
+    {
+        assert!(x < Self::N as u32);
+        assert!(y < Self::N as u32);
+        assert!(z < Self::N as u32);
+        let x = x.expr();
+        let y = y.expr();
+        let z = z.expr();
+        Expr::<Vec3<Self::T>>::from_node(__current_scope(|s| {
+            s.call(
+                Func::Permute,
+                &[self.node(), x.node(), y.node(), z.node()],
+                Vec3::<Self::T>::type_(),
+            )
+        }))
+    }
+    fn _permute4(&self, x: u32, y: u32, z: u32, w: u32) -> Expr<Vec4<Self::T>>
+    where
+        Self::T: VectorAlign<4>,
+    {
+        assert!(x < Self::N as u32);
+        assert!(y < Self::N as u32);
+        assert!(z < Self::N as u32);
+        assert!(w < Self::N as u32);
+        let x = x.expr();
+        let y = y.expr();
+        let z = z.expr();
+        let w = w.expr();
+        Expr::<Vec4<Self::T>>::from_node(__current_scope(|s| {
+            s.call(
+                Func::Permute,
+                &[self.node(), x.node(), y.node(), z.node(), w.node()],
+                Vec4::<Self::T>::type_(),
+            )
+        }))
+    }
+    fn length(&self) -> Expr<Self::T> {
+        Expr::<Self::T>::from_node(__current_scope(|s| {
+            s.call(Func::Length, &[self.node()], Self::T::type_())
+        }))
+    }
+    fn length_squared(&self) -> Expr<Self::T> {
+        Expr::<Self::T>::from_node(__current_scope(|s| {
+            s.call(Func::LengthSquared, &[self.node()], Self::T::type_())
+        }))
+    }
+}

--- a/luisa_compute/src/lang/types/vector/impls.rs
+++ b/luisa_compute/src/lang/types/vector/impls.rs
@@ -1,4 +1,6 @@
 use super::*;
+use crate::lang::index::IntoIndex;
+use std::ops::Index;
 
 impl<T: VectorAlign<N>, const N: usize> From<[T; N]> for Vector<T, N> {
     fn from(elements: [T; N]) -> Self {
@@ -56,7 +58,7 @@ where
 }
 
 macro_rules! impl_sized {
-    ($Vn:ident($N: literal): $($xs:ident),+) => {
+    ($Vn:ident($N: literal), $Vexpr:ident, $Vvar:ident : $($xs:ident),+) => {
         impl<T: VectorAlign<$N>> $Vn<T> {
             pub fn new($($xs: T),+) -> Self {
                 Self {
@@ -68,11 +70,58 @@ macro_rules! impl_sized {
                 Self::expr_from_elements([$($xs.as_expr()),+])
             }
         }
+        impl<T: VectorAlign<$N>> $Vexpr<T> {
+            pub fn dot(&self, other: impl AsExpr<Value = $Vn<T>>) -> Expr<T> {
+                Expr::<T>::from_node(__current_scope(|s| {
+                    s.call(
+                        Func::Dot,
+                        &[self.node(), other.as_expr().node()],
+                        T::type_(),
+                    )
+                }))
+            }
+        }
+        impl<T: VectorAlign<$N>, X: IntoIndex> Index<X> for $Vexpr<T> {
+            type Output = Expr<T>;
+            fn index(&self, i: X) -> &Self::Output {
+                let i = i.to_u64();
+
+                if need_runtime_check() {
+                    lc_assert!(i.lt(($N as u64).expr()));
+                }
+
+                Expr::<T>::from_node(__current_scope(|s| {
+                    s.call(
+                        Func::ExtractElement,
+                        &[self.node(), i.node()],
+                        T::type_(),
+                    )
+                }))._ref()
+            }
+        }
+        impl<T: VectorAlign<$N>, X: IntoIndex> Index<X> for $Vvar<T> {
+            type Output = Var<T>;
+            fn index(&self, i: X) -> &Self::Output {
+                let i = i.to_u64();
+
+                if need_runtime_check() {
+                    lc_assert!(i.lt(($N as u64).expr()));
+                }
+
+                Var::<T>::from_node(__current_scope(|s| {
+                    s.call(
+                        Func::GetElementPtr,
+                        &[self._node, i.node()],
+                        T::type_(),
+                    )
+                }))._ref()
+            }
+        }
     }
 }
-impl_sized!(Vec2(2): x, y);
-impl_sized!(Vec3(3): x, y, z);
-impl_sized!(Vec4(4): x, y, z, w);
+impl_sized!(Vec2(2), VectorExprProxy2, VectorVarProxy2: x, y);
+impl_sized!(Vec3(3), VectorExprProxy3, VectorVarProxy3: x, y, z);
+impl_sized!(Vec4(4), VectorExprProxy4, VectorVarProxy4: x, y, z, w);
 
 pub trait VectorExprProxy {
     const N: usize;
@@ -140,39 +189,6 @@ pub trait VectorExprProxy {
     fn length_squared(&self) -> Expr<Self::T> {
         Expr::<Self::T>::from_node(__current_scope(|s| {
             s.call(Func::LengthSquared, &[self.node()], Self::T::type_())
-        }))
-    }
-}
-impl<T: VectorAlign<2>> VectorExprProxy2<T> {
-    pub fn dot(&self, other: impl AsExpr<Value = Vector<T, 2>>) -> Expr<T> {
-        Expr::<T>::from_node(__current_scope(|s| {
-            s.call(
-                Func::Dot,
-                &[self.node(), other.as_expr().node()],
-                T::type_(),
-            )
-        }))
-    }
-}
-impl<T: VectorAlign<3>> VectorExprProxy3<T> {
-    pub fn dot(&self, other: impl AsExpr<Value = Vector<T, 3>>) -> Expr<T> {
-        Expr::<T>::from_node(__current_scope(|s| {
-            s.call(
-                Func::Dot,
-                &[self.node(), other.as_expr().node()],
-                T::type_(),
-            )
-        }))
-    }
-}
-impl<T: VectorAlign<4>> VectorExprProxy4<T> {
-    pub fn dot(&self, other: impl AsExpr<Value = Vector<T, 4>>) -> Expr<T> {
-        Expr::<T>::from_node(__current_scope(|s| {
-            s.call(
-                Func::Dot,
-                &[self.node(), other.as_expr().node()],
-                T::type_(),
-            )
         }))
     }
 }

--- a/luisa_compute/src/lang/types/vector/impls.rs
+++ b/luisa_compute/src/lang/types/vector/impls.rs
@@ -143,3 +143,36 @@ pub trait VectorExprProxy {
         }))
     }
 }
+impl<T: VectorAlign<2>> VectorExprProxy2<T> {
+    pub fn dot(&self, other: impl AsExpr<Value = Vector<T, 2>>) -> Expr<T> {
+        Expr::<T>::from_node(__current_scope(|s| {
+            s.call(
+                Func::Dot,
+                &[self.node(), other.as_expr().node()],
+                T::type_(),
+            )
+        }))
+    }
+}
+impl<T: VectorAlign<3>> VectorExprProxy3<T> {
+    pub fn dot(&self, other: impl AsExpr<Value = Vector<T, 3>>) -> Expr<T> {
+        Expr::<T>::from_node(__current_scope(|s| {
+            s.call(
+                Func::Dot,
+                &[self.node(), other.as_expr().node()],
+                T::type_(),
+            )
+        }))
+    }
+}
+impl<T: VectorAlign<4>> VectorExprProxy4<T> {
+    pub fn dot(&self, other: impl AsExpr<Value = Vector<T, 4>>) -> Expr<T> {
+        Expr::<T>::from_node(__current_scope(|s| {
+            s.call(
+                Func::Dot,
+                &[self.node(), other.as_expr().node()],
+                T::type_(),
+            )
+        }))
+    }
+}

--- a/luisa_compute/src/lib.rs
+++ b/luisa_compute/src/lib.rs
@@ -32,7 +32,6 @@ pub mod prelude {
         MulAssignExpr, MulExpr, RemAssignExpr, RemExpr, SelectMaybeExpr, ShlAssignExpr, ShlExpr,
         ShrAssignExpr, ShrExpr, SubAssignExpr, SubExpr,
     };
-    pub use crate::lang::types::vector::alias::*;
     pub use crate::lang::types::vector::swizzle::*;
     pub use crate::lang::types::vector::VectorExprProxy;
     pub use crate::lang::types::{AsExpr, Expr, Value, Var};

--- a/luisa_compute/src/lib.rs
+++ b/luisa_compute/src/lib.rs
@@ -24,9 +24,7 @@ pub mod prelude {
     pub use crate::lang::ops::*;
     pub use crate::lang::types::vector::alias::*;
     pub use crate::lang::types::vector::swizzle::*;
-    pub use crate::lang::types::vector::{
-        Mat2, Mat3, Mat4, SquareMatrix, Vec2, Vec3, Vec4, Vector,
-    };
+    pub use crate::lang::types::vector::VectorExprProxy;
     pub use crate::lang::types::{AsExpr, Expr, Value, Var};
     pub use crate::lang::Aggregate;
     pub use crate::resource::{IoTexel, StorageTexel, *};

--- a/luisa_compute/src/lib.rs
+++ b/luisa_compute/src/lib.rs
@@ -13,6 +13,8 @@ pub mod resource;
 pub mod rtx;
 pub mod runtime;
 
+pub use crate::lang::ops::{max, min};
+
 pub mod prelude {
     pub use half::f16;
 
@@ -21,7 +23,15 @@ pub mod prelude {
     };
     pub use crate::lang::functions::{block_size, dispatch_id, dispatch_size, set_block_size};
     pub use crate::lang::index::{IndexRead, IndexWrite};
-    pub use crate::lang::ops::*;
+    pub use crate::lang::ops::{
+        AbsExpr, ActivateMaybeExpr, AddAssignExpr, AddExpr, BitAndAssignExpr, BitAndExpr,
+        BitOrAssignExpr, BitOrExpr, BitXorAssignExpr, BitXorExpr, ClampExpr, CmpExpr,
+        DivAssignExpr, DivExpr, EqExpr, FloatArcTan2Expr, FloatCopySignExpr, FloatExpr,
+        FloatLerpExpr, FloatLogExpr, FloatMulAddExpr, FloatPowfExpr, FloatPowiExpr,
+        FloatSmoothStepExpr, FloatStepExpr, IntExpr, LazyBoolMaybeExpr, LoopMaybeExpr, MinMaxExpr,
+        MulAssignExpr, MulExpr, RemAssignExpr, RemExpr, SelectMaybeExpr, ShlAssignExpr, ShlExpr,
+        ShrAssignExpr, ShrExpr, SubAssignExpr, SubExpr,
+    };
     pub use crate::lang::types::vector::alias::*;
     pub use crate::lang::types::vector::swizzle::*;
     pub use crate::lang::types::vector::VectorExprProxy;
@@ -45,6 +55,7 @@ mod internal_prelude {
         new_node, register_type, BasicBlock, Const, Func, Instruction, IrBuilder, Node,
         PhiIncoming, Pooled, Type, TypeOf, INVALID_REF,
     };
+    pub(crate) use crate::lang::ops::Linear;
     pub(crate) use crate::lang::types::vector::*;
     pub(crate) use crate::lang::{
         ir, CallFuncTrait, Recorder, __compose, __extract, __insert, __module_pools,

--- a/luisa_compute/src/lib.rs
+++ b/luisa_compute/src/lib.rs
@@ -55,6 +55,7 @@ mod internal_prelude {
         PhiIncoming, Pooled, Type, TypeOf, INVALID_REF,
     };
     pub(crate) use crate::lang::ops::Linear;
+    pub(crate) use crate::lang::types::vector::alias::*;
     pub(crate) use crate::lang::types::vector::*;
     pub(crate) use crate::lang::{
         ir, CallFuncTrait, Recorder, __compose, __extract, __insert, __module_pools,

--- a/luisa_compute/src/printer.rs
+++ b/luisa_compute/src/printer.rs
@@ -128,14 +128,15 @@ impl Printer {
         let item_id = items.len() as u32;
 
         if_!(
-            offset.lt(data.len().cast::<u32>())
-                & (offset + 1 + args.count as u32).le(data.len().cast::<u32>()),
+            offset
+                .lt(data.len().cast::<u32>())
+                .bitand((offset.add(1 + args.count as u32)).le(data.len().cast::<u32>())),
             {
                 data.atomic_fetch_add(0, 1);
                 data.write(offset, item_id);
                 let mut cnt = 0;
                 for (i, pack_fn) in args.pack_fn.iter().enumerate() {
-                    pack_fn(offset + 1 + cnt, &data);
+                    pack_fn(offset.add(1 + cnt), &data);
                     cnt += args.count_per_arg[i] as u32;
                 }
             }

--- a/luisa_compute/src/resource.rs
+++ b/luisa_compute/src/resource.rs
@@ -1680,13 +1680,9 @@ impl<T: Value> IndexRead for BufferVar<T> {
         if need_runtime_check() {
             lc_assert!(i.lt(self.len()));
         }
-        __current_scope(|b| {
-            FromNode::from_node(b.call(
-                Func::BufferRead,
-                &[self.node, ToNode::node(&i)],
-                T::type_(),
-            ))
-        })
+        Expr::<T>::from_node(__current_scope(|b| {
+            b.call(Func::BufferRead, &[self.node, ToNode::node(&i)], T::type_())
+        }))
     }
 }
 impl<T: Value> IndexWrite for BufferVar<T> {

--- a/luisa_compute/src/resource.rs
+++ b/luisa_compute/src/resource.rs
@@ -1274,6 +1274,12 @@ impl<T: IoTexel> Tex2d<T> {
     pub fn format(&self) -> PixelFormat {
         self.handle.format
     }
+    pub fn read(&self, uv: impl Into<Expr<Uint2>>) -> Expr<T> {
+        self.var().read(uv)
+    }
+    pub fn write(&self, uv: impl Into<Expr<Uint2>>, v: impl Into<Expr<T>>) {
+        self.var().write(uv, v)
+    }
 }
 impl<T: IoTexel> Tex3d<T> {
     pub fn view(&self, level: u32) -> Tex3dView<T> {
@@ -1293,6 +1299,12 @@ impl<T: IoTexel> Tex3d<T> {
     }
     pub fn format(&self) -> PixelFormat {
         self.handle.format
+    }
+    pub fn read(&self, uv: impl Into<Expr<Uint3>>) -> Expr<T> {
+        self.var().read(uv)
+    }
+    pub fn write(&self, uv: impl Into<Expr<Uint3>>, v: impl Into<Expr<T>>) {
+        self.var().write(uv, v)
     }
 }
 #[derive(Clone)]

--- a/luisa_compute_track/src/lib.rs
+++ b/luisa_compute_track/src/lib.rs
@@ -142,6 +142,16 @@ impl VisitMut for TraceVisitor {
                         return;
                     }
                 }
+                let left = if let Expr::Paren(ExprParen { expr, .. }) = &**left {
+                    expr
+                } else {
+                    left
+                };
+                let right = if let Expr::Paren(ExprParen { expr, .. }) = &**right {
+                    expr
+                } else {
+                    right
+                };
                 let op_fn_str = match &expr.op {
                     BinOp::Add(_) => "__add",
                     BinOp::Sub(_) => "__sub",

--- a/luisa_compute_track/src/lib.rs
+++ b/luisa_compute_track/src/lib.rs
@@ -54,7 +54,7 @@ impl VisitMut for TraceVisitor {
                 }) = &**left
                 {
                     *node = parse_quote_spanned! {span=>
-                        <_ as #trait_path::StoreMaybeExpr>::store(#expr, #right)
+                        <_ as #trait_path::StoreMaybeExpr<_>>::store(#expr, #right)
                     }
                 }
             }

--- a/luisa_compute_track/src/lib.rs
+++ b/luisa_compute_track/src/lib.rs
@@ -98,16 +98,16 @@ impl VisitMut for TraceVisitor {
             }
             Expr::Binary(expr) => {
                 let op_fn_str = match &expr.op {
-                    BinOp::Eq(_) => "eq",
-                    BinOp::Ne(_) => "ne",
+                    BinOp::Eq(_) => "__eq",
+                    BinOp::Ne(_) => "__ne",
 
-                    BinOp::And(_) => "and",
-                    BinOp::Or(_) => "or",
+                    BinOp::And(_) => "__and",
+                    BinOp::Or(_) => "__or",
 
-                    BinOp::Lt(_) => "lt",
-                    BinOp::Le(_) => "le",
-                    BinOp::Ge(_) => "ge",
-                    BinOp::Gt(_) => "gt",
+                    BinOp::Lt(_) => "__lt",
+                    BinOp::Le(_) => "__le",
+                    BinOp::Ge(_) => "__ge",
+                    BinOp::Gt(_) => "__gt",
                     _ => "",
                 };
 
@@ -115,11 +115,11 @@ impl VisitMut for TraceVisitor {
                     let left = &expr.left;
                     let right = &expr.right;
                     let op_fn = Ident::new(op_fn_str, expr.op.span());
-                    if op_fn_str == "eq" || op_fn_str == "ne" {
+                    if op_fn_str == "__eq" || op_fn_str == "__ne" {
                         *node = parse_quote_spanned! {span=>
                             <_ as #trait_path::EqMaybeExpr<_, _>>::#op_fn(#left, #right)
                         }
-                    } else if op_fn_str == "and" || op_fn_str == "or" {
+                    } else if op_fn_str == "__and" || op_fn_str == "__or" {
                         *node = parse_quote_spanned! {span=>
                             <_ as #trait_path::LazyBoolMaybeExpr<_>>::#op_fn(#left, || #right)
                         }

--- a/luisa_compute_track/src/lib.rs
+++ b/luisa_compute_track/src/lib.rs
@@ -186,8 +186,14 @@ impl VisitMut for TraceVisitor {
                 if !op_fn_str.is_empty() {
                     let op_fn = Ident::new(op_fn_str, expr.op.span());
                     let op_trait = Ident::new(op_trait_str, expr.op.span());
-                    *node = parse_quote_spanned! {span=>
-                        <_ as #trait_path::#op_trait<_, _>>::#op_fn(#left, #right)
+                    if let BinOp::And(_) | BinOp::Or(_) = &expr.op {
+                        *node = parse_quote_spanned! {span=>
+                            <_ as #trait_path::#op_trait<_, _>>::#op_fn(#left, || #right)
+                        };
+                    } else {
+                        *node = parse_quote_spanned! {span=>
+                            <_ as #trait_path::#op_trait<_, _>>::#op_fn(#left, #right)
+                        };
                     }
                 }
             }

--- a/luisa_compute_track/src/lib.rs
+++ b/luisa_compute_track/src/lib.rs
@@ -98,16 +98,63 @@ impl VisitMut for TraceVisitor {
             }
             Expr::Binary(expr) => {
                 let op_fn_str = match &expr.op {
+                    BinOp::Add(_) => "__add",
+                    BinOp::Sub(_) => "__sub",
+                    BinOp::Mul(_) => "__mul",
+                    BinOp::Div(_) => "__div",
+                    BinOp::Rem(_) => "__rem",
+                    BinOp::BitAnd(_) => "__bitand",
+                    BinOp::BitOr(_) => "__bitor",
+                    BinOp::BitXor(_) => "__bitxor",
+                    BinOp::Shl(_) => "__shl",
+                    BinOp::Shr(_) => "__shr",
+
+                    BinOp::And(_) => "and",
+                    BinOp::Or(_) => "or",
+
                     BinOp::Eq(_) => "__eq",
                     BinOp::Ne(_) => "__ne",
-
-                    BinOp::And(_) => "__and",
-                    BinOp::Or(_) => "__or",
-
                     BinOp::Lt(_) => "__lt",
                     BinOp::Le(_) => "__le",
                     BinOp::Ge(_) => "__ge",
                     BinOp::Gt(_) => "__gt",
+
+                    BinOp::AddAssign(_) => "__add_assign",
+                    BinOp::SubAssign(_) => "__sub_assign",
+                    BinOp::MulAssign(_) => "__mul_assign",
+                    BinOp::DivAssign(_) => "__div_assign",
+                    BinOp::RemAssign(_) => "__rem_assign",
+                    BinOp::BitAndAssign(_) => "__bitand_assign",
+                    BinOp::BitOrAssign(_) => "__bitor_assign",
+                    BinOp::BitXorAssign(_) => "__bitxor_assign",
+                    BinOp::ShlAssign(_) => "__shl_assign",
+                    BinOp::ShrAssign(_) => "__shr_assign",
+                    _ => "",
+                };
+                let op_trait_str = match &expr.op {
+                    BinOp::Add(_) => "AddMaybeExpr",
+                    BinOp::Sub(_) => "SubMaybeExpr",
+                    BinOp::Mul(_) => "MulMaybeExpr",
+                    BinOp::Div(_) => "DivMaybeExpr",
+                    BinOp::Rem(_) => "RemMaybeExpr",
+                    BinOp::BitAnd(_) => "BitAndMaybeExpr",
+                    BinOp::BitOr(_) => "BitOrMaybeExpr",
+                    BinOp::BitXor(_) => "BitXorMaybeExpr",
+                    BinOp::Shl(_) => "ShlMaybeExpr",
+                    BinOp::Shr(_) => "ShrMaybeExpr",
+                    BinOp::And(_) | BinOp::Or(_) => "LazyBoolMaybeExpr",
+                    BinOp::Eq(_) | BinOp::Ne(_) => "EqMaybeExpr",
+                    BinOp::Lt(_) | BinOp::Le(_) | BinOp::Ge(_) | BinOp::Gt(_) => "CmpMaybeExpr",
+                    BinOp::AddAssign(_) => "AddAssignMaybeExpr",
+                    BinOp::SubAssign(_) => "SubAssignMaybeExpr",
+                    BinOp::MulAssign(_) => "MulAssignMaybeExpr",
+                    BinOp::DivAssign(_) => "DivAssignMaybeExpr",
+                    BinOp::RemAssign(_) => "RemAssignMaybeExpr",
+                    BinOp::BitAndAssign(_) => "BitAndAssignMaybeExpr",
+                    BinOp::BitOrAssign(_) => "BitOrAssignMaybeExpr",
+                    BinOp::BitXorAssign(_) => "BitXorAssignMaybeExpr",
+                    BinOp::ShlAssign(_) => "ShlAssignMaybeExpr",
+                    BinOp::ShrAssign(_) => "ShrAssignMaybeExpr",
                     _ => "",
                 };
 
@@ -115,18 +162,9 @@ impl VisitMut for TraceVisitor {
                     let left = &expr.left;
                     let right = &expr.right;
                     let op_fn = Ident::new(op_fn_str, expr.op.span());
-                    if op_fn_str == "__eq" || op_fn_str == "__ne" {
-                        *node = parse_quote_spanned! {span=>
-                            <_ as #trait_path::EqMaybeExpr<_, _>>::#op_fn(#left, #right)
-                        }
-                    } else if op_fn_str == "__and" || op_fn_str == "__or" {
-                        *node = parse_quote_spanned! {span=>
-                            <_ as #trait_path::LazyBoolMaybeExpr<_>>::#op_fn(#left, || #right)
-                        }
-                    } else {
-                        *node = parse_quote_spanned! {span=>
-                            <_ as #trait_path::CmpMaybeExpr<_, _>>::#op_fn(#left, #right)
-                        }
+                    let op_trait = Ident::new(op_trait_str, expr.op.span());
+                    *node = parse_quote_spanned! {span=>
+                        <_ as #trait_path::#op_trait<_, _>>::#op_fn(#left, #right)
                     }
                 }
             }


### PR DESCRIPTION
Relies on `VarProxy::as_var_from_proxy` and `ExprProxy::as_expr_from_proxy`, so that should to be implemented before merging (there are ways of getting around it, but tbh I'd like those to exist).