### PR TITLE
Refactor kernel creation

### DIFF
--- a/luisa_compute/examples/atomic.rs
+++ b/luisa_compute/examples/atomic.rs
@@ -10,12 +10,15 @@ fn main() {
     let sum = device.create_buffer::<f32>(1);
     x.view(..).fill_fn(|i| i as f32);
     sum.view(..).fill(0.0);
-    let shader = device.create_kernel::<fn()>(&track!(|| {
-        let buf_x = x.var();
-        let buf_sum = sum.var();
-        let tid = dispatch_id().x;
-        buf_sum.atomic_fetch_add(0, buf_x.read(tid));
-    }));
+    let shader = Kernel::<fn()>::new(
+        &device,
+        track!(|| {
+            let buf_x = x.var();
+            let buf_sum = sum.var();
+            let tid = dispatch_id().x;
+            buf_sum.atomic_fetch_add(0, buf_x.read(tid));
+        }),
+    );
     shader.dispatch([x.len() as u32, 1, 1]);
     let mut sum_data = vec![0.0];
     sum.view(..).copy_to(&mut sum_data);

--- a/luisa_compute/examples/autodiff.rs
+++ b/luisa_compute/examples/autodiff.rs
@@ -29,7 +29,7 @@ fn main() {
     let dy_gt = device.create_buffer::<f32>(1024);
     x.fill_fn(|i| i as f32);
     y.fill_fn(|i| 1.0 + i as f32);
-    let shader = device.create_kernel::<fn()>(track!(&|| {
+    let shader = Kernel::<fn()>::new(&device, track!(|| {
         let tid = dispatch_id().x;
         let buf_x = x.var();
         let buf_y = y.var();

--- a/luisa_compute/examples/backtrace.rs
+++ b/luisa_compute/examples/backtrace.rs
@@ -24,7 +24,7 @@ fn main() {
     let z = device.create_buffer::<f32>(1024);
     x.view(..).fill_fn(|i| i as f32);
     y.view(..).fill_fn(|i| 1000.0 * i as f32);
-    let kernel = device.create_kernel::<fn(Buffer<f32>)>(track!(&|buf_z| {
+    let kernel = Kernel::<fn(Buffer<f32>)>::new(&device, track!(|buf_z| {
         // z is pass by arg
         let buf_x = x.var(); // x and y are captured
         let buf_y = y.var();

--- a/luisa_compute/examples/bindgroup.rs
+++ b/luisa_compute/examples/bindgroup.rs
@@ -22,6 +22,6 @@ fn main() {
         y,
         exclude: 42.0,
     };
-    let shader = device.create_kernel::<fn(MyArgStruct<f32>)>(&|_args| {});
+    let shader = Kernel::<fn(MyArgStruct<f32>)>::new(&device, |_args| {});
     shader.dispatch([1024, 1, 1], &my_args);
 }

--- a/luisa_compute/examples/bindless.rs
+++ b/luisa_compute/examples/bindless.rs
@@ -62,7 +62,7 @@ fn main() {
     bindless.emplace_buffer_async(1, &y);
     bindless.emplace_tex2d_async(0, &img, Sampler::default());
     bindless.update();
-    let kernel = device.create_kernel::<fn(Buffer<f32>)>(&track!(|buf_z| {
+    let kernel = Kernel::<fn(Buffer<f32>)>::new(&device, track!(|buf_z| {
         let bindless = bindless.var();
         let tid = dispatch_id().x;
         let buf_x = bindless.buffer::<f32>(0_u32.expr());

--- a/luisa_compute/examples/callable.rs
+++ b/luisa_compute/examples/callable.rs
@@ -18,13 +18,13 @@ fn main() {
         "cpu"
     });
     let add =
-        device.create_callable::<fn(Expr<f32>, Expr<f32>) -> Expr<f32>>(&|a, b| track!(a + b));
+       Callable::<fn(Expr<f32>, Expr<f32>) -> Expr<f32>>::new(&device, |a, b| track!(a + b));
     let x = device.create_buffer::<f32>(1024);
     let y = device.create_buffer::<f32>(1024);
     let z = device.create_buffer::<f32>(1024);
     x.view(..).fill_fn(|i| i as f32);
     y.view(..).fill_fn(|i| 1000.0 * i as f32);
-    let kernel = device.create_kernel::<fn(Buffer<f32>)>(&track!(|buf_z| {
+    let kernel = Kernel::<fn(Buffer<f32>)>::new(&device, track!(|buf_z| {
         let buf_x = x.var();
         let buf_y = y.var();
         let tid = dispatch_id().x;

--- a/luisa_compute/examples/callable_advanced.rs
+++ b/luisa_compute/examples/callable_advanced.rs
@@ -18,8 +18,9 @@ fn main() {
     } else {
         "cpu"
     });
-    let add = device.create_dyn_callable::<fn(DynExpr, DynExpr) -> DynExpr>(Box::new(
-        |a: DynExpr, b: DynExpr| -> DynExpr {
+    let add = DynCallable::<fn(DynExpr, DynExpr) -> DynExpr>::new(
+        &device,
+        Box::new(|a: DynExpr, b: DynExpr| -> DynExpr {
             if let Some(a) = a.downcast::<f32>() {
                 let b = b.downcast::<f32>().unwrap();
                 return DynExpr::new(track!(a + b));
@@ -29,28 +30,31 @@ fn main() {
             } else {
                 unreachable!()
             }
-        },
-    ));
+        }),
+    );
     let x = device.create_buffer::<f32>(1024);
     let y = device.create_buffer::<f32>(1024);
     let z = device.create_buffer::<f32>(1024);
     let w = device.create_buffer::<i32>(1024);
     x.view(..).fill_fn(|i| i as f32);
     y.view(..).fill_fn(|i| 1000.0 * i as f32);
-    let kernel = device.create_kernel::<fn(Buffer<f32>)>(&track!(|buf_z| {
-        let buf_x = x.var();
-        let buf_y = y.var();
-        let tid = dispatch_id().x;
-        let x = buf_x.read(tid);
-        let y = buf_y.read(tid);
+    let kernel = Kernel::<fn(Buffer<f32>)>::new(
+        &device,
+        track!(|buf_z| {
+            let buf_x = x.var();
+            let buf_y = y.var();
+            let tid = dispatch_id().x;
+            let x = buf_x.read(tid);
+            let y = buf_y.read(tid);
 
-        buf_z.write(tid, add.call(x.into(), y.into()).get::<f32>());
-        w.var().write(
-            tid,
-            add.call(x.as_::<i32>().into(), y.as_::<i32>().into())
-                .get::<i32>(),
-        );
-    }));
+            buf_z.write(tid, add.call(x.into(), y.into()).get::<f32>());
+            w.var().write(
+                tid,
+                add.call(x.as_::<i32>().into(), y.as_::<i32>().into())
+                    .get::<i32>(),
+            );
+        }),
+    );
     kernel.dispatch([1024, 1, 1], &z);
     let z_data = z.view(..).copy_to_vec();
     println!("{:?}", &z_data[0..16]);

--- a/luisa_compute/examples/path_tracer.rs
+++ b/luisa_compute/examples/path_tracer.rs
@@ -8,7 +8,9 @@ use winit::event_loop::EventLoop;
 
 use luisa::lang::types::vector::{alias::*, *};
 use luisa::prelude::*;
-use luisa::rtx::{offset_ray_origin, Accel, AccelBuildRequest, AccelOption, AccelVar, Index, Ray, RayComps};
+use luisa::rtx::{
+    offset_ray_origin, Accel, AccelBuildRequest, AccelOption, AccelVar, Index, Ray, RayComps,
+};
 use luisa_compute as luisa;
 
 #[derive(Value, Clone, Copy)]
@@ -244,11 +246,12 @@ fn main() {
     });
 
     // use create_kernel_async to compile multiple kernels in parallel
-    let path_tracer = device.create_kernel_async::<fn(Tex2d<Float4>, Tex2d<u32>, Accel, Uint2)>(
-        track!(&|image: Tex2dVar<Float4>,
-                 seed_image: Tex2dVar<u32>,
-                 accel: AccelVar,
-                 resolution: Expr<Uint2>| {
+    let path_tracer = Kernel::<fn(Tex2d<Float4>, Tex2d<u32>, Accel, Uint2)>::new_async(
+        &device,
+        track!(|image: Tex2dVar<Float4>,
+                seed_image: Tex2dVar<u32>,
+                accel: AccelVar,
+                resolution: Expr<Uint2>| {
             set_block_size([16u32, 16u32, 1u32]);
             let cbox_materials = ([
                 Float3::new(0.725f32, 0.710f32, 0.680f32), // floor
@@ -263,7 +266,7 @@ fn main() {
             .expr();
 
             let lcg = |state: Var<u32>| -> Expr<f32> {
-                let lcg = create_static_callable::<fn(Var<u32>) -> Expr<f32>>(|state: Var<u32>| {
+                let lcg = Callable::<fn(Var<u32>) -> Expr<f32>>::new_static(|state: Var<u32>| {
                     const LCG_A: u32 = 1664525u32;
                     const LCG_C: u32 = 1013904223u32;
                     *state = LCG_A * state + LCG_C;
@@ -278,7 +281,7 @@ fn main() {
                         orig: o.into(),
                         tmin: tmin,
                         dir: d.into(),
-                        tmax: tmax
+                        tmax: tmax,
                     })
                 };
 
@@ -455,8 +458,9 @@ fn main() {
             );
         }),
     );
-    let display =
-        device.create_kernel_async::<fn(Tex2d<Float4>, Tex2d<Float4>)>(track!(&|acc, display| {
+    let display = Kernel::<fn(Tex2d<Float4>, Tex2d<Float4>)>::new_async(
+        &device,
+        track!(|acc, display| {
             set_block_size([16, 16, 1]);
             let coord = dispatch_id().xy();
             let radiance = acc.read(coord);
@@ -468,7 +472,8 @@ fn main() {
 
             let srgb = radiance.lt(0.0031308).select(radiance * 12.92, r);
             display.write(coord, Float4::expr(srgb.x, srgb.y, srgb.z, 1.0f32));
-        }));
+        }),
+    );
     let img_w = 1024;
     let img_h = 1024;
     let acc_img = device.create_tex2d::<Float4>(PixelStorage::Float4, img_w, img_h, 1);

--- a/luisa_compute/examples/printer.rs
+++ b/luisa_compute/examples/printer.rs
@@ -21,7 +21,7 @@ fn main() {
         "cpu"
     });
     let printer = Printer::new(&device, 65536);
-    let kernel = device.create_kernel::<fn()>(track!(&|| {
+    let kernel = Kernel::<fn()>::new(&device, track!(|| {
         let id = dispatch_id().xy();
         if id.x == id.y {
             lc_info!(printer, "id = {:?}", id);

--- a/luisa_compute/examples/ray_query.rs
+++ b/luisa_compute/examples/ray_query.rs
@@ -119,93 +119,98 @@ fn main() {
     let img_h = 800;
     let img = device.create_tex2d::<Float4>(PixelStorage::Byte4, img_w, img_h, 1);
     let debug_hit_t = device.create_buffer::<f32>(4);
-    let rt_kernel = device.create_kernel::<fn()>(&track!(|| {
-        let accel = accel.var();
-        let px = dispatch_id().xy();
-        let xy = px.as_float2() / Float2::expr(img_w as f32, img_h as f32);
-        let xy = 2.0 * xy - 1.0;
-        let o = Float3::expr(0.0, 0.0, -2.0);
-        let d = Float3::expr(xy.x, xy.y, 0.0) - o;
-        let d = d.normalize();
+    let rt_kernel = Kernel::<fn()>::new(
+        &device,
+        track!(|| {
+            let accel = accel.var();
+            let px = dispatch_id().xy();
+            let xy = px.as_float2() / Float2::expr(img_w as f32, img_h as f32);
+            let xy = 2.0 * xy - 1.0;
+            let o = Float3::expr(0.0, 0.0, -2.0);
+            let d = Float3::expr(xy.x, xy.y, 0.0) - o;
+            let d = d.normalize();
 
-        let ray = Ray::new_expr(
-            Expr::<[f32; 3]>::from(o + translate.expr()),
-            1e-3f32,
-            Expr::<[f32; 3]>::from(d),
-            1e9f32,
-        );
-        let hit = accel.query_all(
-            ray,
-            255,
-            RayQuery {
-                on_triangle_hit: |candidate: TriangleCandidate| {
-                    let bary = candidate.bary;
-                    let uvw = Float3::expr(1.0 - bary.x - bary.y, bary.x, bary.y);
-                    let t = candidate.committed_ray_t;
-                    if (px == Uint2::expr(400, 400)).all() {
-                        debug_hit_t.write(0, t);
-                        debug_hit_t.write(1, candidate.ray().tmax);
-                    };
-                    // if (uvw.xy().length() < 0.8)
-                    //     & (uvw.yz().length() < 0.8)
-                    //     & (uvw.xz().length() < 0.8)
-                    if uvw.xy().length() < 0.8 && uvw.yz().length() < 0.8 && uvw.xz().length() < 0.8
-                    {
-                        candidate.commit();
-                    }
-                },
-                on_procedural_hit: |candidate: ProceduralCandidate| {
-                    let ray = candidate.ray();
-                    let prim = candidate.prim;
-                    let sphere = spheres.var().read(prim);
-                    let o: Expr<Float3> = ray.orig.into();
-                    let d: Expr<Float3> = ray.dir.into();
-                    let t = Var::<f32>::zeroed();
-
-                    for _ in 0..100 {
-                        let dist = (o + d * t - (sphere.center + translate.expr())).length()
-                            - sphere.radius;
-                        if dist < 0.001 {
-                            if (px == Uint2::expr(400, 400)).all() {
-                                debug_hit_t.write(2, t);
-                                debug_hit_t.write(3, candidate.ray().tmax);
-                            }
-                            if t < ray.tmax {
-                                candidate.commit(t);
-                            }
-                            break;
+            let ray = Ray::new_expr(
+                Expr::<[f32; 3]>::from(o + translate.expr()),
+                1e-3f32,
+                Expr::<[f32; 3]>::from(d),
+                1e9f32,
+            );
+            let hit = accel.query_all(
+                ray,
+                255,
+                RayQuery {
+                    on_triangle_hit: |candidate: TriangleCandidate| {
+                        let bary = candidate.bary;
+                        let uvw = Float3::expr(1.0 - bary.x - bary.y, bary.x, bary.y);
+                        let t = candidate.committed_ray_t;
+                        if (px == Uint2::expr(400, 400)).all() {
+                            debug_hit_t.write(0, t);
+                            debug_hit_t.write(1, candidate.ray().tmax);
+                        };
+                        // if (uvw.xy().length() < 0.8)
+                        //     & (uvw.yz().length() < 0.8)
+                        //     & (uvw.xz().length() < 0.8)
+                        if uvw.xy().length() < 0.8
+                            && uvw.yz().length() < 0.8
+                            && uvw.xz().length() < 0.8
+                        {
+                            candidate.commit();
                         }
-                        *t += dist;
-                    }
-                },
-            },
-        );
-        let img = img.view(0).var();
-        let color = if hit.triangle_hit() {
-            let bary = hit.bary;
-            let uvw = Float3::expr(1.0 - bary.x - bary.y, bary.x, bary.y);
-            uvw
-        } else {
-            if hit.procedural_hit() {
-                let prim = hit.prim_id;
-                let sphere = spheres.var().read(prim);
-                let normal = (Expr::<Float3>::from(ray.orig)
-                    + Expr::<Float3>::from(ray.dir) * hit.committed_ray_t
-                    - sphere.center)
-                    .normalize();
-                let light_dir = Float3::expr(1.0, 0.6, -0.2).normalize();
-                let light = Float3::expr(1.0, 1.0, 1.0);
-                let ambient = Float3::expr(0.1, 0.1, 0.1);
-                let diffuse = luisa::max(light * normal.dot(light_dir), 0.0);
-                let color = ambient + diffuse;
-                color
-            } else {
-                Float3::expr(0.0, 0.0, 0.0)
-            }
-        };
+                    },
+                    on_procedural_hit: |candidate: ProceduralCandidate| {
+                        let ray = candidate.ray();
+                        let prim = candidate.prim;
+                        let sphere = spheres.var().read(prim);
+                        let o: Expr<Float3> = ray.orig.into();
+                        let d: Expr<Float3> = ray.dir.into();
+                        let t = Var::<f32>::zeroed();
 
-        img.write(px, Float4::expr(color.x, color.y, color.z, 1.0));
-    }));
+                        for _ in 0..100 {
+                            let dist = (o + d * t - (sphere.center + translate.expr())).length()
+                                - sphere.radius;
+                            if dist < 0.001 {
+                                if (px == Uint2::expr(400, 400)).all() {
+                                    debug_hit_t.write(2, t);
+                                    debug_hit_t.write(3, candidate.ray().tmax);
+                                }
+                                if t < ray.tmax {
+                                    candidate.commit(t);
+                                }
+                                break;
+                            }
+                            *t += dist;
+                        }
+                    },
+                },
+            );
+            let img = img.view(0).var();
+            let color = if hit.triangle_hit() {
+                let bary = hit.bary;
+                let uvw = Float3::expr(1.0 - bary.x - bary.y, bary.x, bary.y);
+                uvw
+            } else {
+                if hit.procedural_hit() {
+                    let prim = hit.prim_id;
+                    let sphere = spheres.var().read(prim);
+                    let normal = (Expr::<Float3>::from(ray.orig)
+                        + Expr::<Float3>::from(ray.dir) * hit.committed_ray_t
+                        - sphere.center)
+                        .normalize();
+                    let light_dir = Float3::expr(1.0, 0.6, -0.2).normalize();
+                    let light = Float3::expr(1.0, 1.0, 1.0);
+                    let ambient = Float3::expr(0.1, 0.1, 0.1);
+                    let diffuse = luisa::max(light * normal.dot(light_dir), 0.0);
+                    let color = ambient + diffuse;
+                    color
+                } else {
+                    Float3::expr(0.0, 0.0, 0.0)
+                }
+            };
+
+            img.write(px, Float4::expr(color.x, color.y, color.z, 1.0));
+        }),
+    );
     let event_loop = EventLoop::new();
     let window = winit::window::WindowBuilder::new()
         .with_title("Luisa Compute Rust - Ray Query")

--- a/luisa_compute/examples/raytracing.rs
+++ b/luisa_compute/examples/raytracing.rs
@@ -36,7 +36,7 @@ fn main() {
     let img_w = 800;
     let img_h = 800;
     let img = device.create_tex2d::<Float4>(PixelStorage::Byte4, img_w, img_h, 1);
-    let rt_kernel = device.create_kernel::<fn()>(&track!(|| {
+    let rt_kernel = Kernel::<fn()>::new(&device,track!(|| {
         let accel = accel.var();
         let px = dispatch_id().xy();
         let xy = px.as_::<Float2>() / Float2::expr(img_w as f32, img_h as f32);

--- a/luisa_compute/examples/vecadd.rs
+++ b/luisa_compute/examples/vecadd.rs
@@ -2,8 +2,9 @@ use std::env::current_exe;
 
 use luisa::lang::types::vector::alias::*;
 use luisa::prelude::*;
-use std::cell::RefCell;
+use luisa::runtime::{Kernel, KernelDef};
 use luisa_compute as luisa;
+use std::cell::RefCell;
 fn main() {
     luisa::init_logger();
     let args: Vec<String> = std::env::args().collect();
@@ -24,18 +25,21 @@ fn main() {
     let z = device.create_buffer::<f32>(1024);
     x.view(..).fill_fn(|i| i as f32);
     y.view(..).fill_fn(|i| 1000.0 * i as f32);
-    let kernel = device.create_kernel::<fn(Buffer<f32>)>(track!(&|buf_z| {
-        // z is pass by arg
-        let buf_x = x.var(); // x and y are captured
-        let buf_y = y.var();
-        let tid = dispatch_id().x;
-        let x = buf_x.read(tid);
-        let y = buf_y.read(tid);
-        let vx = 2.0_f32.var(); // create a local mutable variable
-        *vx += x; // store to vx
-        *vx = vx;
-        buf_z.write(tid, vx + y);
-    }));
+
+    let kernel = Kernel::<fn(Buffer<f32>)>::new(
+        &device,
+        track!(|buf_z| {
+            // z is pass by arg
+            let buf_x = x.var(); // x and y are captured
+            let buf_y = y.var();
+            let tid = dispatch_id().x;
+            let x = buf_x.read(tid);
+            let y = buf_y.read(tid);
+            let vx = 2.0_f32.var(); // create a local mutable variable
+            *vx += x; // store to vx
+            buf_z.write(tid, vx + y);
+        }),
+    );
     kernel.dispatch([1024, 1, 1], &z);
     let z_data = z.view(..).copy_to_vec();
     println!("{:?}", &z_data[0..16]);

--- a/luisa_compute/src/lib.rs
+++ b/luisa_compute/src/lib.rs
@@ -40,7 +40,8 @@ pub mod prelude {
     pub use crate::resource::{IoTexel, StorageTexel, *};
     pub use crate::runtime::api::StreamTag;
     pub use crate::runtime::{
-        create_static_callable, Command, Device, KernelBuildOptions, Scope, Stream,
+        Callable, Command, Device, DynCallable, Kernel, KernelBuildOptions, KernelDef, Scope,
+        Stream,
     };
     pub use crate::{cpu_dbg, if_, lc_assert, lc_unreachable, loop_, while_, Context};
 
@@ -155,6 +156,7 @@ impl Context {
     }
 }
 
+#[derive(Clone)]
 pub struct ResourceTracker {
     resources: Vec<Arc<dyn Any>>,
 }

--- a/luisa_compute/src/printer.rs
+++ b/luisa_compute/src/printer.rs
@@ -149,31 +149,8 @@ impl Printer {
             count_per_arg: args.count_per_arg,
         });
     }
-    pub fn reset(&self) -> PrinterReset {
-        PrinterReset { inner: self }
-    }
-    pub fn print(&self) -> PrinterPrint {
-        PrinterPrint { inner: self }
-    }
 }
-pub struct PrinterPrint<'a> {
-    inner: &'a Printer,
-}
-pub struct PrinterReset<'a> {
-    inner: &'a Printer,
-}
-impl<'a> std::ops::Shl<PrinterPrint<'a>> for &'a Scope<'a> {
-    type Output = Self;
-    fn shl(self, rhs: PrinterPrint<'a>) -> Self::Output {
-        self.print(rhs.inner)
-    }
-}
-impl<'a> std::ops::Shl<PrinterReset<'a>> for &'a Scope<'a> {
-    type Output = Self;
-    fn shl(self, rhs: PrinterReset<'a>) -> Self::Output {
-        self.reset_printer(rhs.inner)
-    }
-}
+
 impl<'a> Scope<'a> {
     pub fn reset_printer(&self, printer: &Printer) -> &Self {
         printer

--- a/luisa_compute/src/rtx.rs
+++ b/luisa_compute/src/rtx.rs
@@ -391,7 +391,7 @@ pub enum HitType {
 pub fn offset_ray_origin(p: Expr<Float3>, n: Expr<Float3>) -> Expr<Float3> {
     lazy_static! {
         static ref F: Callable<fn(Expr<Float3>, Expr<Float3>) -> Expr<Float3>> =
-            create_static_callable::<fn(Expr<Float3>, Expr<Float3>) -> Expr<Float3>>(|p, n| {
+            Callable::<fn(Expr<Float3>, Expr<Float3>) -> Expr<Float3>>::new_static(|p, n| {
                 const ORIGIN: f32 = 1.0f32 / 32.0f32;
                 const FLOAT_SCALE: f32 = 1.0f32 / 65536.0f32;
                 const INT_SCALE: f32 = 256.0f32;
@@ -473,7 +473,7 @@ impl Deref for TriangleCandidate {
     }
 }
 impl ProceduralCandidate {
-    pub fn commit(&self, t: impl AsExpr<Value=f32>) {
+    pub fn commit(&self, t: impl AsExpr<Value = f32>) {
         let t = t.as_expr();
         __current_scope(|b| {
             b.call(

--- a/luisa_compute/src/runtime.rs
+++ b/luisa_compute/src/runtime.rs
@@ -1213,14 +1213,14 @@ pub struct KernelDef<T: KernelSignature> {
 /// An executable kernel
 /// Kernel creation can be done in multiple ways:
 /// - Seperate recording and compilation:
-/// ```no_run
+/// ```rust
 /// // Recording:
 /// let kernel = KernelDef::<fn(Buffer<f32>, Buffer<f32>, Buffer<f32>)>::new(&device, track!(|a,b,c|{ ... }));
 /// // Compilation:
 /// let kernel = device.compile_kernel(&kernel);
 /// ```
 /// - Recording and compilation in one step:
-/// ```no_run
+/// ```rust
 /// let kernel = Kernel::<fn(Buffer<f32>, Buffer<f32>, Buffer<f32>)>::new(&device, track!(|a,b,c|{ ... }));
 /// ```
 /// - Asynchronous compilation use [`Kernel::<T>::new_async`]

--- a/luisa_compute/src/runtime.rs
+++ b/luisa_compute/src/runtime.rs
@@ -202,7 +202,7 @@ impl Device {
             }),
             _marker: PhantomData {},
             len: count,
-            _is_byte_buffer:false,
+            _is_byte_buffer: false,
         };
         buffer
     }
@@ -400,93 +400,59 @@ impl Device {
             modifications: RwLock::new(HashMap::new()),
         }
     }
-    pub fn create_callable<'a, S: CallableSignature<'a>>(&self, f: S::Fn) -> S::Callable {
-        let mut builder = KernelBuilder::new(Some(self.clone()), false);
-        let raw_callable = CallableBuildFn::build_callable(&f, None, &mut builder);
-        S::wrap_raw_callable(raw_callable)
+
+    /// Compile a [`KernelDef`] into a [`Kernel`]. See [`Kernel`] for more details on kernel creation
+    pub fn compile_kernel<S: KernelSignature>(&self, k: &KernelDef<S>) -> Kernel<S> {
+        self.compile_kernel_with_options(k, KernelBuildOptions::default())
     }
-    pub fn create_dyn_callable<'a, S: CallableSignature<'a>>(&self, f: S::DynFn) -> S::DynCallable {
-        S::create_dyn_callable(self.clone(), false, f)
-    }
-    pub fn create_dyn_callable_once<'a, S: CallableSignature<'a>>(
-        &self,
-        f: S::DynFn,
-    ) -> S::DynCallable {
-        S::create_dyn_callable(self.clone(), true, f)
-    }
-    pub fn create_kernel<'a, S: KernelSignature<'a>>(&self, f: S::Fn) -> S::Kernel {
-        let mut builder = KernelBuilder::new(Some(self.clone()), true);
-        let raw_kernel =
-            KernelBuildFn::build_kernel(&f, &mut builder, KernelBuildOptions::default());
-        S::wrap_raw_kernel(raw_kernel)
-    }
-    pub fn create_kernel_async<'a, S: KernelSignature<'a>>(&self, f: S::Fn) -> S::Kernel {
-        let mut builder = KernelBuilder::new(Some(self.clone()), true);
-        let raw_kernel = KernelBuildFn::build_kernel(
-            &f,
-            &mut builder,
+
+    /// Compile a [`KernelDef`] into a [`Kernel`] asynchronously. See [`Kernel`] for more details on kernel creation
+    pub fn compile_kernel_async<S: KernelSignature>(&self, k: &KernelDef<S>) -> Kernel<S> {
+        self.compile_kernel_with_options(
+            k,
             KernelBuildOptions {
                 async_compile: true,
                 ..Default::default()
             },
-        );
-        S::wrap_raw_kernel(raw_kernel)
+        )
     }
-    pub fn create_kernel_with_options<'a, S: KernelSignature<'a>>(
-        &self,
-        f: S::Fn,
-        options: KernelBuildOptions,
-    ) -> S::Kernel {
-        let mut builder = KernelBuilder::new(Some(self.clone()), true);
-        let raw_kernel = KernelBuildFn::build_kernel(&f, &mut builder, options);
-        S::wrap_raw_kernel(raw_kernel)
-    }
-}
 
-pub fn create_static_callable<'a, S: CallableSignature<'a>>(f: S::StaticFn) -> S::Callable {
-    let r_backup = RECORDER.with(|r| {
-        let mut r = r.borrow_mut();
-        std::mem::replace(&mut *r, Recorder::new())
-    });
-    let mut builder = KernelBuilder::new(None, false);
-    let raw_callable = CallableBuildFn::build_callable(&f, None, &mut builder);
-    let callable = S::wrap_raw_callable(raw_callable);
-    RECORDER.with(|r| {
-        *r.borrow_mut() = r_backup;
-    });
-    callable
-}
-#[macro_export]
-macro_rules! fn_n_args {
-    (0)=>{ dyn Fn()};
-    (1)=>{ dyn Fn(_)};
-    (2)=>{ dyn Fn(_,_)};
-    (3)=>{ dyn Fn(_,_,_)};
-    (4)=>{ dyn Fn(_,_,_,_)};
-    (5)=>{ dyn Fn(_,_,_,_,_)};
-    (6)=>{ dyn Fn(_,_,_,_,_,_)};
-    (7)=>{ dyn Fn(_,_,_,_,_,_,_)};
-    (8)=>{ dyn Fn(_,_,_,_,_,_,_,_)};
-    (9)=>{ dyn Fn(_,_,_,_,_,_,_,_,_)};
-    (10)=>{dyn Fn(_,_,_,_,_,_,_,_,_,_)};
-    (11)=>{dyn Fn(_,_,_,_,_,_,_,_,_,_,_)};
-    (12)=>{dyn Fn(_,_,_,_,_,_,_,_,_,_,_,_)};
-    (13)=>{dyn Fn(_,_,_,_,_,_,_,_,_,_,_,_,_)};
-    (14)=>{dyn Fn(_,_,_,_,_,_,_,_,_,_,_,_,_,_)};
-    (15)=>{dyn Fn(_,_,_,_,_,_,_,_,_,_,_,_,_,_,_)};
-}
-#[macro_export]
-macro_rules! wrap_fn {
-    ($arg_count:tt, $f:expr) => {
-        &$f as &fn_n_args!($arg_count)
-    };
-}
-#[macro_export]
-macro_rules! create_kernel {
-    ($device:expr, $arg_count:tt, $f:expr) => {{
-        let kernel: fn_n_args!($arg_count) = Box::new($f);
-        $device.create_kernel(kernel)
-    }};
+    /// Compile a [`KernelDef`] into a [`Kernel`] with options. See [`Kernel`] for more details on kernel creation
+    pub fn compile_kernel_with_options<S: KernelSignature>(
+        &self,
+        k: &KernelDef<S>,
+        options: KernelBuildOptions,
+    ) -> Kernel<S> {
+        let name = options.name.unwrap_or("".to_string());
+        let name = Arc::new(CString::new(name).unwrap());
+        let shader_options = api::ShaderOption {
+            enable_cache: options.enable_cache,
+            enable_fast_math: options.enable_fast_math,
+            enable_debug_info: options.enable_debug_info,
+            compile_only: false,
+            name: name.as_ptr(),
+        };
+        let module = k.inner.module.clone();
+        let artifact = if options.async_compile {
+            ShaderArtifact::Async(AsyncShaderArtifact::new(
+                self.clone(),
+                module.clone(),
+                shader_options,
+                name,
+            ))
+        } else {
+            ShaderArtifact::Sync(self.inner.create_shader(&module, &shader_options))
+        };
+        Kernel {
+            inner: RawKernel {
+                device: self.clone(),
+                artifact,
+                module,
+                resource_tracker: k.inner.resource_tracker.clone(),
+            },
+            _marker: PhantomData {},
+        }
+    }
 }
 pub(crate) enum StreamHandle {
     Default {
@@ -793,31 +759,6 @@ impl<'a> Scope<'a> {
         self
     }
 }
-impl<'a> std::ops::Shl<Command<'a>> for &'a Scope<'a> {
-    type Output = Self;
-    #[inline]
-    #[allow(unused_must_use)]
-    fn shl(self, rhs: Command<'a>) -> Self::Output {
-        self.submit(std::iter::once(rhs));
-        self
-    }
-}
-impl<'a> std::ops::Shl<EventSignal<'a>> for &'a Scope<'a> {
-    type Output = Self;
-    #[inline]
-    #[allow(unused_must_use)]
-    fn shl(self, rhs: EventSignal<'a>) -> Self::Output {
-        self.signal(rhs.event, rhs.ticket)
-    }
-}
-impl<'a> std::ops::Shl<EventWait<'a>> for &'a Scope<'a> {
-    type Output = Self;
-    #[inline]
-    #[allow(unused_must_use)]
-    fn shl(self, rhs: EventWait<'a>) -> Self::Output {
-        self.wait(rhs.event, rhs.ticket)
-    }
-}
 impl<'a> Drop for Scope<'a> {
     fn drop(&mut self) {
         if !self.synchronized.get() {
@@ -939,7 +880,7 @@ pub struct RawKernel {
     pub(crate) artifact: ShaderArtifact,
     #[allow(dead_code)]
     pub(crate) resource_tracker: ResourceTracker,
-    pub(crate) module: CArc<ir::KernelModule>,
+    pub(crate) module: CArc<KernelModule>,
 }
 
 pub struct CallableArgEncoder {
@@ -1111,17 +1052,17 @@ macro_rules! impl_kernel_arg_for_tuple {
             fn encode(&self, _: &mut KernelArgEncoder) { }
         }
     };
-    ($first:ident  $($rest:ident) *) => {
-        impl<$first:KernelArg, $($rest: KernelArg),*> KernelArg for ($first, $($rest,)*) {
-            type Parameter = ($first::Parameter, $($rest::Parameter),*);
+    ($first:ident  $($Ts:ident) *) => {
+        impl<$first:KernelArg, $($Ts: KernelArg),*> KernelArg for ($first, $($Ts,)*) {
+            type Parameter = ($first::Parameter, $($Ts::Parameter),*);
             #[allow(non_snake_case)]
             fn encode(&self, encoder: &mut KernelArgEncoder) {
-                let ($first, $($rest,)*) = self;
+                let ($first, $($Ts,)*) = self;
                 $first.encode(encoder);
-                $($rest.encode(encoder);)*
+                $($Ts.encode(encoder);)*
             }
         }
-        impl_kernel_arg_for_tuple!($($rest)*);
+        impl_kernel_arg_for_tuple!($($Ts)*);
     };
 
 }
@@ -1142,6 +1083,7 @@ impl RawKernel {
             }
         }
     }
+
     pub fn dispatch_async(&self, args: KernelArgEncoder, dispatch_size: [u32; 3]) -> Command {
         let mut rt = ResourceTracker::new();
         rt.add(Arc::new(args.uniform_data));
@@ -1165,23 +1107,23 @@ impl RawKernel {
     }
 }
 
-pub struct Callable<S: CallableSignature<'static>> {
+pub struct Callable<S: CallableSignature> {
     #[allow(dead_code)]
     pub(crate) inner: RawCallable,
     pub(crate) _marker: PhantomData<S>,
 }
-pub(crate) struct DynCallableInner<S: CallableSignature<'static>> {
+pub(crate) struct DynCallableInner<S: CallableSignature> {
     builder: Box<dyn Fn(std::rc::Rc<dyn Any>, &mut KernelBuilder) -> Callable<S>>,
     callables: Vec<Callable<S>>,
 }
-pub struct DynCallable<S: CallableSignature<'static>> {
+pub struct DynCallable<S: CallableSignature> {
     #[allow(dead_code)]
     pub(crate) inner: RefCell<DynCallableInner<S>>,
     pub(crate) device: Device,
     pub(crate) init_once: bool,
 }
-impl<S: CallableSignature<'static>> DynCallable<S> {
-    pub(crate) fn new(
+impl<S: CallableSignature> DynCallable<S> {
+    pub(crate) fn _new(
         device: Device,
         init_once: bool,
         builder: Box<dyn Fn(std::rc::Rc<dyn Any>, &mut KernelBuilder) -> Callable<S>>,
@@ -1253,14 +1195,45 @@ pub struct RawCallable {
     #[allow(dead_code)]
     pub(crate) resource_tracker: ResourceTracker,
 }
+pub struct RawKernelDef {
+    #[allow(dead_code)]
+    pub(crate) device: Option<Device>,
+    pub(crate) module: CArc<KernelModule>,
+    #[allow(dead_code)]
+    pub(crate) resource_tracker: ResourceTracker,
+}
 
-pub struct Kernel<T: KernelSignature<'static>> {
+/// A kernel definition
+/// See [`Kernel<T>`] for more information
+pub struct KernelDef<T: KernelSignature> {
+    pub(crate) inner: RawKernelDef,
+    pub(crate) _marker: PhantomData<T>,
+}
+
+/// An executable kernel
+/// Kernel creation can be done in multiple ways:
+/// - Seperate recording and compilation:
+/// ```no_run
+/// // Recording:
+/// let kernel = KernelDef::<fn(Buffer<f32>, Buffer<f32>, Buffer<f32>)>::new(&device, track!(|a,b,c|{ ... }));
+/// // Compilation:
+/// let kernel = device.compile_kernel(&kernel);
+/// ```
+/// - Recording and compilation in one step:
+/// ```no_run
+/// let kernel = Kernel::<fn(Buffer<f32>, Buffer<f32>, Buffer<f32>)>::new(&device, track!(|a,b,c|{ ... }));
+/// ```
+/// - Asynchronous compilation use [`Kernel::<T>::new_async`]
+/// - Custom build options using [`Kernel::<T>::new_with_options`]
+/// ```
+///
+pub struct Kernel<T: KernelSignature> {
     pub(crate) inner: RawKernel,
     pub(crate) _marker: PhantomData<T>,
 }
-unsafe impl<T: KernelSignature<'static>> Send for Kernel<T> {}
-unsafe impl<T: KernelSignature<'static>> Sync for Kernel<T> {}
-impl<T: KernelSignature<'static>> Kernel<T> {
+unsafe impl<T: KernelSignature> Send for Kernel<T> {}
+unsafe impl<T: KernelSignature> Sync for Kernel<T> {}
+impl<T: KernelSignature> Kernel<T> {
     pub fn cache_dir(&self) -> Option<PathBuf> {
         let handle = self.inner.unwrap();
         let device = &self.inner.device;
@@ -1302,80 +1275,101 @@ impl<T: IoTexel> AsKernelArg<Tex3d<T>> for Tex3d<T> {}
 impl AsKernelArg<BindlessArray> for BindlessArray {}
 
 impl AsKernelArg<Accel> for Accel {}
+
 macro_rules! impl_call_for_callable {
-    ($first:ident  $($rest:ident)*) => {
-        impl <R:CallableRet+'static, $first:CallableParameter, $($rest: CallableParameter),*> Callable<fn($first, $($rest,)*)->R> {
+    ( $($Ts:ident)*) => {
+        impl <R:CallableRet+'static, $($Ts: CallableParameter),*> Callable<fn($($Ts,)*)->R> {
             #[allow(non_snake_case)]
-            pub fn call(&self, $first:$first, $($rest:$rest),*) -> R {
+            #[allow(unused_mut)]
+            pub fn call(&self, $($Ts:$Ts),*) -> R {
                 let mut encoder = CallableArgEncoder::new();
-                $first.encode(&mut encoder);
-                $($rest.encode(&mut encoder);)*
+                $($Ts.encode(&mut encoder);)*
                 CallableRet::_from_return(
                     crate::lang::__invoke_callable(&self.inner.module, &encoder.args))
             }
         }
-        impl <R:CallableRet+'static, $first:CallableParameter, $($rest: CallableParameter),*> DynCallable<fn($first, $($rest,)*)->R> {
+        impl <R:CallableRet+'static, $($Ts: CallableParameter),*> DynCallable<fn($($Ts,)*)->R> {
             #[allow(non_snake_case)]
-            pub fn call(&self, $first:$first, $($rest:$rest),*) -> R {
+            #[allow(unused_mut)]
+            pub fn call(&self, $($Ts:$Ts),*) -> R {
                 let mut encoder = CallableArgEncoder::new();
-                $first.encode(&mut encoder);
-                $($rest.encode(&mut encoder);)*
-                self.call_impl(std::rc::Rc::new(($first, $($rest,)*)), &encoder.args)
+                $($Ts.encode(&mut encoder);)*
+                self.call_impl(std::rc::Rc::new(($($Ts,)*)), &encoder.args)
             }
         }
-        impl_call_for_callable!($($rest)*);
    };
-   ()=>{
-        impl<R:CallableRet+'static> Callable<fn()->R> {
-            pub fn call(&self)->R {
-                CallableRet::_from_return(
-                    crate::lang::__invoke_callable(&self.inner.module, &[]))
-            }
-        }
-        impl<R:CallableRet+'static> DynCallable<fn()->R> {
-            pub fn call(&self)-> R{
-                self.call_impl(std::rc::Rc::new(()), &[])
-            }
-        }
-    }
 }
+impl_call_for_callable!();
+impl_call_for_callable!(T0);
+impl_call_for_callable!(T0 T1 );
+impl_call_for_callable!(T0 T1 T2 );
+impl_call_for_callable!(T0 T1 T2 T3 );
+impl_call_for_callable!(T0 T1 T2 T3 T4 );
+impl_call_for_callable!(T0 T1 T2 T3 T4 T5 );
+impl_call_for_callable!(T0 T1 T2 T3 T4 T5 T6 );
+impl_call_for_callable!(T0 T1 T2 T3 T4 T5 T6 T7 );
+impl_call_for_callable!(T0 T1 T2 T3 T4 T5 T6 T7 T8 );
+impl_call_for_callable!(T0 T1 T2 T3 T4 T5 T6 T7 T8 T9 );
+impl_call_for_callable!(T0 T1 T2 T3 T4 T5 T6 T7 T8 T9 T10 );
+impl_call_for_callable!(T0 T1 T2 T3 T4 T5 T6 T7 T8 T9 T10 T11 );
+impl_call_for_callable!(T0 T1 T2 T3 T4 T5 T6 T7 T8 T9 T10 T11 T12 );
+impl_call_for_callable!(T0 T1 T2 T3 T4 T5 T6 T7 T8 T9 T10 T11 T12 T13 );
+impl_call_for_callable!(T0 T1 T2 T3 T4 T5 T6 T7 T8 T9 T10 T11 T12 T13 T14 );
 impl_call_for_callable!(T0 T1 T2 T3 T4 T5 T6 T7 T8 T9 T10 T11 T12 T13 T14 T15);
+
 macro_rules! impl_dispatch_for_kernel {
 
-   ($first:ident  $($rest:ident)*) => {
-        impl <$first:KernelArg+'static, $($rest: KernelArg+'static),*> Kernel<fn($first, $($rest,)*)> {
+   ($($Ts:ident)*) => {
+        impl <$($Ts: KernelArg+'static),*> Kernel<fn($($Ts,)*)> {
             #[allow(non_snake_case)]
-            pub fn dispatch(&self, dispatch_size: [u32; 3], $first:&impl AsKernelArg<$first>, $($rest:&impl AsKernelArg<$rest>),*)  {
+            #[allow(unused_mut)]
+            pub fn dispatch(&self, dispatch_size: [u32; 3], $($Ts:&impl AsKernelArg<$Ts>),*)  {
                 let mut encoder = KernelArgEncoder::new();
-                $first.encode(&mut encoder);
-                $($rest.encode(&mut encoder);)*
+                $($Ts.encode(&mut encoder);)*
                 self.inner.dispatch(encoder, dispatch_size)
             }
             #[allow(non_snake_case)]
+            #[allow(unused_mut)]
             pub fn dispatch_async<'a>(
                 &'a self,
-                dispatch_size: [u32; 3], $first: &impl AsKernelArg<$first>, $($rest:&impl AsKernelArg<$rest>),*
+                dispatch_size: [u32; 3], $($Ts:&impl AsKernelArg<$Ts>),*
             ) -> Command<'a> {
                 let mut encoder = KernelArgEncoder::new();
-                $first.encode(&mut encoder);
-                $($rest.encode(&mut encoder);)*
+                $($Ts.encode(&mut encoder);)*
                 self.inner.dispatch_async(encoder, dispatch_size)
             }
+            /// Blocks until the kernel is compiled
+            pub fn ensure_ready(&self) {
+                self.inner.unwrap();
+            }
         }
-        impl_dispatch_for_kernel!($($rest)*);
    };
-   ()=>{
-    impl Kernel<fn()> {
-        pub fn dispatch(&self, dispatch_size: [u32; 3])  {
-            self.inner.dispatch(KernelArgEncoder::new(), dispatch_size)
-        }
-        pub fn dispatch_async<'a>(
-            &'a self,
-            dispatch_size: [u32; 3],
-        ) -> Command<'a> {
-            self.inner.dispatch_async(KernelArgEncoder::new(), dispatch_size)
-        }
-    }
 }
-}
+
+impl_dispatch_for_kernel!();
+impl_dispatch_for_kernel!(T0);
+impl_dispatch_for_kernel!(T0 T1 );
+impl_dispatch_for_kernel!(T0 T1 T2 );
+impl_dispatch_for_kernel!(T0 T1 T2 T3 );
+impl_dispatch_for_kernel!(T0 T1 T2 T3 T4 );
+impl_dispatch_for_kernel!(T0 T1 T2 T3 T4 T5 );
+impl_dispatch_for_kernel!(T0 T1 T2 T3 T4 T5 T6 );
+impl_dispatch_for_kernel!(T0 T1 T2 T3 T4 T5 T6 T7 );
+impl_dispatch_for_kernel!(T0 T1 T2 T3 T4 T5 T6 T7 T8 );
+impl_dispatch_for_kernel!(T0 T1 T2 T3 T4 T5 T6 T7 T8 T9 );
+impl_dispatch_for_kernel!(T0 T1 T2 T3 T4 T5 T6 T7 T8 T9 T10 );
+impl_dispatch_for_kernel!(T0 T1 T2 T3 T4 T5 T6 T7 T8 T9 T10 T11 );
+impl_dispatch_for_kernel!(T0 T1 T2 T3 T4 T5 T6 T7 T8 T9 T10 T11 T12 );
+impl_dispatch_for_kernel!(T0 T1 T2 T3 T4 T5 T6 T7 T8 T9 T10 T11 T12 T13 );
+impl_dispatch_for_kernel!(T0 T1 T2 T3 T4 T5 T6 T7 T8 T9 T10 T11 T12 T13 T14 );
 impl_dispatch_for_kernel!(T0 T1 T2 T3 T4 T5 T6 T7 T8 T9 T10 T11 T12 T13 T14 T15);
+
+#[macro_export]
+macro_rules! remove_last {
+    ($x:ident) => {
+
+    };
+    ($first:ident $($xs:ident)*) => {
+        $first remove_last!($($xs)*)
+    };
+}

--- a/luisa_compute/src/runtime.rs
+++ b/luisa_compute/src/runtime.rs
@@ -1213,19 +1213,24 @@ pub struct KernelDef<T: KernelSignature> {
 /// An executable kernel
 /// Kernel creation can be done in multiple ways:
 /// - Seperate recording and compilation:
-/// ```rust
-/// // Recording:
-/// let kernel = KernelDef::<fn(Buffer<f32>, Buffer<f32>, Buffer<f32>)>::new(&device, track!(|a,b,c|{ ... }));
+/// ```no_run
+//// // Recording:
+/// use luisa_compute::prelude::*;
+/// let ctx = Context::new(std::env::current_exe().unwrap());
+/// let device = ctx.create_device("cpu");
+/// let kernel = KernelDef::<fn(Buffer<f32>, Buffer<f32>, Buffer<f32>)>::new(&device, track!(|a,b,c|{  }));
 /// // Compilation:
 /// let kernel = device.compile_kernel(&kernel);
 /// ```
 /// - Recording and compilation in one step:
-/// ```rust
-/// let kernel = Kernel::<fn(Buffer<f32>, Buffer<f32>, Buffer<f32>)>::new(&device, track!(|a,b,c|{ ... }));
+/// ```no_run
+/// use luisa_compute::prelude::*;
+/// let ctx = Context::new(std::env::current_exe().unwrap());
+/// let device = ctx.create_device("cpu");
+/// let kernel = Kernel::<fn(Buffer<f32>, Buffer<f32>, Buffer<f32>)>::new(&device, track!(|a,b,c|{ }));
 /// ```
 /// - Asynchronous compilation use [`Kernel::<T>::new_async`]
 /// - Custom build options using [`Kernel::<T>::new_with_options`]
-/// ```
 ///
 pub struct Kernel<T: KernelSignature> {
     pub(crate) inner: RawKernel,


### PR DESCRIPTION
Replace `device.create_kernel::<fn(...)>(&closue)` with `Kernel::<fn()>::new(...)`. This allows type alias `type K = Kernel<...>` to be used in creation `K::new(...)`.
Similar change has been made for callables.