### PR TITLE
Nested callable

### DIFF
--- a/luisa_compute/examples/fluid.rs
+++ b/luisa_compute/examples/fluid.rs
@@ -225,18 +225,6 @@ fn main() {
         }),
     );
 
-    let init_grid = Kernel::<fn()>::new_async(&device, &|| {
-        let idx = index(dispatch_id().xy());
-        u0.var().write(idx, Float2::expr(0.0f32, 0.0f32));
-        u1.var().write(idx, Float2::expr(0.0f32, 0.0f32));
-
-        rho0.var().write(idx, 0.0f32);
-        rho1.var().write(idx, 0.0f32);
-
-        p0.var().write(idx, 0.0f32);
-        p1.var().write(idx, 0.0f32);
-        div.var().write(idx, 0.0f32);
-    });
 
     let clear_pressure = Kernel::<fn()>::new_async(&device, &|| {
         let idx = index(dispatch_id().xy());

--- a/luisa_compute/examples/nested_callable.rs
+++ b/luisa_compute/examples/nested_callable.rs
@@ -1,0 +1,49 @@
+use luisa::prelude::*;
+use luisa_compute as luisa;
+use std::env::current_exe;
+
+fn main() {
+    luisa::init_logger();
+    let args: Vec<String> = std::env::args().collect();
+    assert!(
+        args.len() <= 2,
+        "Usage: {} <backend>. <backend>: cpu, cuda, dx, metal, remote",
+        args[0]
+    );
+
+    let ctx = Context::new(current_exe().unwrap());
+    let device = ctx.create_device(if args.len() == 2 {
+        args[1].as_str()
+    } else {
+        "cpu"
+    });
+
+    let add = track!(Callable::<fn(Expr<f32>, Expr<f32>) -> Expr<f32>>::new(
+        &device,
+        |a, b| {
+            // callables can be defined within callables
+            let partial_add = Callable::<fn(Expr<f32>) -> Expr<f32>>::new(&device, |y| a + y);
+            partial_add.call(b)
+        }
+    ));
+    let x = device.create_buffer::<f32>(1024);
+    let y = device.create_buffer::<f32>(1024);
+    let z = device.create_buffer::<f32>(1024);
+    x.view(..).fill_fn(|i| i as f32);
+    y.view(..).fill_fn(|i| 1000.0 * i as f32);
+    let kernel = Kernel::<fn(Buffer<f32>)>::new(
+        &device,
+        &track!(|buf_z| {
+            let buf_x = x.var();
+            let buf_y = y.var();
+            let tid = dispatch_id().x;
+            let x = buf_x.read(tid);
+            let y = buf_y.read(tid);
+
+            buf_z.write(tid, add.call(x, y));
+        }),
+    );
+    kernel.dispatch([1024, 1, 1], &z);
+    let z_data = z.view(..).copy_to_vec();
+    println!("{:?}", &z_data[0..16]);
+}

--- a/luisa_compute/examples/vecadd.rs
+++ b/luisa_compute/examples/vecadd.rs
@@ -1,8 +1,5 @@
 use std::env::current_exe;
-
-use luisa::lang::types::vector::alias::*;
 use luisa::prelude::*;
-use luisa::runtime::{Kernel, KernelDef};
 use luisa_compute as luisa;
 #[tracked]
 fn main() {

--- a/luisa_compute/src/lang.rs
+++ b/luisa_compute/src/lang.rs
@@ -1,6 +1,8 @@
 use std::any::Any;
 use std::cell::{Cell, RefCell};
 use std::fmt::Debug;
+use std::ops::Deref;
+use std::rc::Rc;
 use std::sync::atomic::AtomicUsize;
 use std::sync::Arc;
 use std::{env, unreachable};
@@ -8,7 +10,7 @@ use std::{env, unreachable};
 use crate::internal_prelude::*;
 
 use bumpalo::Bump;
-use indexmap::IndexMap;
+use indexmap::{IndexMap, IndexSet};
 
 use crate::runtime::WeakDevice;
 
@@ -26,16 +28,16 @@ use ir::{
 
 use self::index::IntoIndex;
 
+pub mod autodiff;
 pub mod control_flow;
 pub mod debug;
-pub mod autodiff;
+pub mod external;
 pub mod functions;
 pub mod index;
 pub mod ops;
 pub mod poly;
 pub mod soa;
 pub mod types;
-pub mod external;
 
 pub(crate) trait CallFuncTrait {
     fn call<T: Value, S: Value>(self, x: Expr<T>) -> Expr<S>;
@@ -52,17 +54,17 @@ pub(crate) trait CallFuncTrait {
 }
 impl CallFuncTrait for Func {
     fn call<T: Value, S: Value>(self, x: Expr<T>) -> Expr<S> {
-        let x = x.node();
-        Expr::<S>::from_node(__current_scope(|b| {
+        let x = process_potential_capture(x.node()).node;
+        Expr::<S>::from_node(make_safe_node(__current_scope(|b| {
             b.call(self, &[x], <S as TypeOf>::type_())
-        }))
+        })))
     }
     fn call2<T: Value, S: Value, U: Value>(self, x: Expr<T>, y: Expr<S>) -> Expr<U> {
-        let x = x.node();
-        let y = y.node();
-        Expr::<U>::from_node(__current_scope(|b| {
+        let x = process_potential_capture(x.node()).node;
+        let y = process_potential_capture(y.node()).node;
+        Expr::<U>::from_node(make_safe_node(__current_scope(|b| {
             b.call(self, &[x, y], <U as TypeOf>::type_())
-        }))
+        })))
     }
     fn call3<T: Value, S: Value, U: Value, V: Value>(
         self,
@@ -70,76 +72,98 @@ impl CallFuncTrait for Func {
         y: Expr<S>,
         z: Expr<U>,
     ) -> Expr<V> {
-        let x = x.node();
-        let y = y.node();
-        let z = z.node();
-        Expr::<V>::from_node(__current_scope(|b| {
+        let x = process_potential_capture(x.node()).node;
+        let y = process_potential_capture(y.node()).node;
+        let z = process_potential_capture(z.node()).node;
+
+        Expr::<V>::from_node(make_safe_node(__current_scope(|b| {
             b.call(self, &[x, y, z], <V as TypeOf>::type_())
-        }))
+        })))
     }
     fn call_void<T: Value>(self, x: Expr<T>) {
-        let x = x.node();
+        let x = process_potential_capture(x.node()).node;
         __current_scope(|b| {
             b.call(self, &[x], Type::void());
         });
     }
     fn call2_void<T: Value, S: Value>(self, x: Expr<T>, y: Expr<S>) {
-        let x = x.node();
-        let y = y.node();
+        let x = process_potential_capture(x.node()).node;
+        let y = process_potential_capture(y.node()).node;
         __current_scope(|b| {
             b.call(self, &[x, y], Type::void());
         });
     }
     fn call3_void<T: Value, S: Value, U: Value>(self, x: Expr<T>, y: Expr<S>, z: Expr<U>) {
-        let x = x.node();
-        let y = y.node();
-        let z = z.node();
+        let x = process_potential_capture(x.node()).node;
+        let y = process_potential_capture(y.node()).node;
+        let z = process_potential_capture(z.node()).node;
         __current_scope(|b| {
             b.call(self, &[x, y, z], Type::void());
         });
     }
 }
 
-#[allow(dead_code)]
+/**
+ * Prevents sharing node across kernels
+ * KERNEL_ID is incremented each time a new kernel starts recording
+ * For callables defined within the kernel, they have the same kernel_id
+ */
 pub(crate) static KERNEL_ID: AtomicUsize = AtomicUsize::new(0);
-// prevent node being shared across kernels
-// TODO: replace NodeRef with SafeNodeRef
-#[derive(Clone, Copy, Debug)]
-pub(crate) struct SafeNodeRef {
-    #[allow(dead_code)]
-    pub(crate) node: NodeRef,
-    #[allow(dead_code)]
+
+#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq)]
+pub struct SafeNodeRef {
+    /// if two nodes have the same kernel_id
+    /// this pointer is safe to use
+    pub(crate) recorder: *mut FnRecorder,
+    node: NodeRef,
     pub(crate) kernel_id: usize,
+}
+impl SafeNodeRef {
+    /// get node after processing capture
+    ///
+    /// **DO NOT CACHE THIS NODE!!**
+    /// `get()` returns different node according to the context
+    pub fn get(&self) -> NodeRef {
+        process_potential_capture(*self).node
+    }
+    pub unsafe fn get_raw(&self) -> NodeRef {
+        self.node
+    }
+}
+impl From<NodeRef> for SafeNodeRef {
+    fn from(value: NodeRef) -> Self {
+        make_safe_node(value)
+    }
 }
 
 pub trait Aggregate: Sized {
-    fn to_vec_nodes(&self) -> Vec<NodeRef> {
+    fn to_vec_nodes(&self) -> Vec<SafeNodeRef> {
         let mut nodes = vec![];
         Self::to_nodes(&self, &mut nodes);
         nodes
     }
-    fn from_vec_nodes(nodes: Vec<NodeRef>) -> Self {
+    fn from_vec_nodes(nodes: Vec<SafeNodeRef>) -> Self {
         let mut iter = nodes.into_iter();
         let ret = Self::from_nodes(&mut iter);
         assert!(iter.next().is_none());
         ret
     }
-    fn to_nodes(&self, nodes: &mut Vec<NodeRef>);
-    fn from_nodes<I: Iterator<Item = NodeRef>>(iter: &mut I) -> Self;
+    fn to_nodes(&self, nodes: &mut Vec<SafeNodeRef>);
+    fn from_nodes<I: Iterator<Item = SafeNodeRef>>(iter: &mut I) -> Self;
 }
 
 impl<T: Aggregate> Aggregate for Vec<T> {
-    fn to_nodes(&self, nodes: &mut Vec<NodeRef>) {
-        let len_node = new_user_node(__module_pools(), nodes.len());
+    fn to_nodes(&self, nodes: &mut Vec<SafeNodeRef>) {
+        let len_node = __new_user_node(nodes.len());
         nodes.push(len_node);
         for item in self {
             item.to_nodes(nodes);
         }
     }
 
-    fn from_nodes<I: Iterator<Item = NodeRef>>(iter: &mut I) -> Self {
+    fn from_nodes<I: Iterator<Item = SafeNodeRef>>(iter: &mut I) -> Self {
         let len_node = iter.next().unwrap();
-        let len = len_node.unwrap_user_data::<usize>();
+        let len = len_node.get().unwrap_user_data::<usize>();
         let mut ret = Vec::with_capacity(*len);
         for _ in 0..*len {
             ret.push(T::from_nodes(iter));
@@ -149,41 +173,41 @@ impl<T: Aggregate> Aggregate for Vec<T> {
 }
 
 impl<T: Aggregate> Aggregate for RefCell<T> {
-    fn to_nodes(&self, nodes: &mut Vec<NodeRef>) {
+    fn to_nodes(&self, nodes: &mut Vec<SafeNodeRef>) {
         self.borrow().to_nodes(nodes);
     }
 
-    fn from_nodes<I: Iterator<Item = NodeRef>>(iter: &mut I) -> Self {
+    fn from_nodes<I: Iterator<Item = SafeNodeRef>>(iter: &mut I) -> Self {
         RefCell::new(T::from_nodes(iter))
     }
 }
 impl<T: Aggregate + Copy> Aggregate for Cell<T> {
-    fn to_nodes(&self, nodes: &mut Vec<NodeRef>) {
+    fn to_nodes(&self, nodes: &mut Vec<SafeNodeRef>) {
         self.get().to_nodes(nodes);
     }
 
-    fn from_nodes<I: Iterator<Item = NodeRef>>(iter: &mut I) -> Self {
+    fn from_nodes<I: Iterator<Item = SafeNodeRef>>(iter: &mut I) -> Self {
         Cell::new(T::from_nodes(iter))
     }
 }
 impl<T: Aggregate> Aggregate for Option<T> {
-    fn to_nodes(&self, nodes: &mut Vec<NodeRef>) {
+    fn to_nodes(&self, nodes: &mut Vec<SafeNodeRef>) {
         match self {
             Some(x) => {
-                let node = new_user_node(__module_pools(), 1);
+                let node = __new_user_node(1usize);
                 nodes.push(node);
                 x.to_nodes(nodes);
             }
             None => {
-                let node = new_user_node(__module_pools(), 0);
+                let node = __new_user_node(0usize);
                 nodes.push(node);
             }
         }
     }
 
-    fn from_nodes<I: Iterator<Item = NodeRef>>(iter: &mut I) -> Self {
+    fn from_nodes<I: Iterator<Item = SafeNodeRef>>(iter: &mut I) -> Self {
         let node = iter.next().unwrap();
-        let tag = node.unwrap_user_data::<usize>();
+        let tag = node.get().unwrap_user_data::<usize>();
         match *tag {
             0 => None,
             1 => Some(T::from_nodes(iter)),
@@ -193,14 +217,14 @@ impl<T: Aggregate> Aggregate for Option<T> {
 }
 
 pub trait ToNode {
-    fn node(&self) -> NodeRef;
+    fn node(&self) -> SafeNodeRef;
 }
 
 pub trait NodeLike: FromNode + ToNode {}
 impl<T> NodeLike for T where T: FromNode + ToNode {}
 
 pub trait FromNode {
-    fn from_node(node: NodeRef) -> Self;
+    fn from_node(node: SafeNodeRef) -> Self;
 }
 
 // impl<T: Default> FromNode for T {
@@ -210,8 +234,16 @@ pub trait FromNode {
 // }
 
 fn _store<T1: Aggregate, T2: Aggregate>(var: &T1, value: &T2) {
-    let value_nodes = value.to_vec_nodes();
-    let self_nodes = var.to_vec_nodes();
+    let value_nodes = value
+        .to_vec_nodes()
+        .into_iter()
+        .map(|x| x.get())
+        .collect::<Vec<_>>();
+    let self_nodes = var
+        .to_vec_nodes()
+        .into_iter()
+        .map(|x| x.get())
+        .collect::<Vec<_>>();
     assert_eq!(value_nodes.len(), self_nodes.len());
     __current_scope(|b| {
         for (value_node, self_node) in value_nodes.into_iter().zip(self_nodes.into_iter()) {
@@ -221,26 +253,31 @@ fn _store<T1: Aggregate, T2: Aggregate>(var: &T1, value: &T2) {
 }
 
 #[inline(always)]
-pub fn __new_user_node<T: UserNodeData>(data: T) -> NodeRef {
-    new_user_node(__module_pools(), data)
+pub fn __new_user_node<T: UserNodeData>(data: T) -> SafeNodeRef {
+    let node = new_user_node(__module_pools(), data);
+    SafeNodeRef {
+        recorder: std::ptr::null_mut(),
+        node,
+        kernel_id: usize::MAX,
+    }
 }
 macro_rules! impl_aggregate_for_tuple {
     ()=>{
         impl Aggregate for () {
-            fn to_nodes(&self, _: &mut Vec<NodeRef>) {}
-            fn from_nodes<I: Iterator<Item = NodeRef>>(_: &mut I) -> Self{}
+            fn to_nodes(&self, _: &mut Vec<SafeNodeRef>) {}
+            fn from_nodes<I: Iterator<Item = SafeNodeRef>>(_: &mut I) -> Self{}
         }
     };
     ($first:ident  $($rest:ident) *) => {
         impl<$first:Aggregate, $($rest: Aggregate),*> Aggregate for ($first, $($rest,)*) {
             #[allow(non_snake_case)]
-            fn to_nodes(&self, nodes: &mut Vec<NodeRef>) {
+            fn to_nodes(&self, nodes: &mut Vec<SafeNodeRef>) {
                 let ($first, $($rest,)*) = self;
                 $first.to_nodes(nodes);
                 $($rest.to_nodes(nodes);)*
             }
             #[allow(non_snake_case)]
-            fn from_nodes<I: Iterator<Item = NodeRef>>(iter: &mut I) -> Self {
+            fn from_nodes<I: Iterator<Item = SafeNodeRef>>(iter: &mut I) -> Self {
                 let $first = Aggregate::from_nodes(iter);
                 $(let $rest = Aggregate::from_nodes(iter);)*
                 ($first, $($rest,)*)
@@ -252,13 +289,14 @@ macro_rules! impl_aggregate_for_tuple {
 }
 impl_aggregate_for_tuple!(T0 T1 T2 T3 T4 T5 T6 T7 T8 T9 T10 T11 T12 T13 T14 T15);
 
-pub(crate) struct Recorder {
+pub(crate) struct FnRecorder {
+    pub(crate) parent: Option<FnRecorderPtr>,
     pub(crate) scopes: Vec<IrBuilder>,
     pub(crate) kernel_id: Option<usize>,
-    pub(crate) lock: bool,
     pub(crate) captured_resources: IndexMap<Binding, (usize, NodeRef, Binding, Arc<dyn Any>)>,
     pub(crate) cpu_custom_ops: IndexMap<u64, (usize, CArc<CpuCustomOp>)>,
     pub(crate) callables: IndexMap<u64, CallableModuleRef>,
+    pub(crate) captured_vars: IndexMap<SafeNodeRef, SafeNodeRef>,
     pub(crate) shared: Vec<NodeRef>,
     pub(crate) device: Option<WeakDevice>,
     pub(crate) block_size: Option<[u32; 3]>,
@@ -267,22 +305,8 @@ pub(crate) struct Recorder {
     pub(crate) arena: Bump,
     pub(crate) callable_ret_type: Option<CArc<Type>>,
 }
-
-impl Recorder {
-    pub(crate) fn reset(&mut self) {
-        self.scopes.clear();
-        self.captured_resources.clear();
-        self.cpu_custom_ops.clear();
-        self.callables.clear();
-        self.lock = false;
-        self.device = None;
-        self.block_size = None;
-        self.arena.reset();
-        self.shared.clear();
-        self.kernel_id = None;
-        self.callable_ret_type = None;
-    }
-
+pub(crate) type FnRecorderPtr = Rc<RefCell<FnRecorder>>;
+impl FnRecorder {
     pub(crate) fn check_on_same_device(&mut self, other: &Device) -> Option<(String, String)> {
         if let Some(device) = &self.device {
             let device = device.upgrade().unwrap();
@@ -314,12 +338,12 @@ impl Recorder {
         }
     }
     pub(crate) fn new() -> Self {
-        Recorder {
+        FnRecorder {
             scopes: vec![],
-            lock: false,
             captured_resources: IndexMap::new(),
             cpu_custom_ops: IndexMap::new(),
             callables: IndexMap::new(),
+            captured_vars: IndexMap::new(),
             shared: vec![],
             device: None,
             block_size: None,
@@ -328,26 +352,115 @@ impl Recorder {
             building_kernel: false,
             kernel_id: None,
             callable_ret_type: None,
+            parent: None,
         }
+    }
+    pub(crate) fn map_captured_vars(&mut self, node: SafeNodeRef) -> SafeNodeRef {
+        if node.recorder == self as *mut _ {
+            return node;
+        }
+        if self.captured_vars.contains_key(&node) {
+            return self.captured_vars[&node];
+        }
+        let parent = self
+            .parent
+            .as_mut()
+            .unwrap_or_else(|| panic!("Captured var outside kernel"));
+        match node.node.get().instruction.as_ref() {
+            Instruction::Local { .. } => {}
+            Instruction::Call { .. } => {}
+            Instruction::Argument { .. } => {}
+            _ => {
+                panic!("cannot capture node {:?}", node.node.get().instruction)
+            }
+        }
+        let arg = SafeNodeRef {
+            recorder: self as *mut _,
+            node: new_node(
+                self.pools.as_ref().unwrap(),
+                Node::new(
+                    CArc::new(Instruction::Argument {
+                        by_value: !node.node.is_lvalue(),
+                    }),
+                    node.node.type_().clone(),
+                ),
+            ),
+            kernel_id: node.kernel_id,
+        };
+        self.captured_vars.insert(node, arg);
+        let mut parent = parent.borrow_mut();
+        parent.map_captured_vars(node);
+        arg
     }
 }
 thread_local! {
-    pub(crate) static RECORDER: RefCell<Recorder> = RefCell::new(Recorder::new());
+    pub(crate) static RECORDER: RefCell<Option<FnRecorderPtr>> = RefCell::new(None);
 }
-
-// Don't call this function directly unless you know what you are doing
-pub fn __current_scope<F: FnOnce(&mut IrBuilder) -> R, R>(f: F) -> R {
+fn make_safe_node(node: NodeRef) -> SafeNodeRef {
+    with_recorder(|r| SafeNodeRef {
+        recorder: r as *mut _,
+        node,
+        kernel_id: KERNEL_ID.load(std::sync::atomic::Ordering::Relaxed),
+    })
+}
+/// check if the node belongs to the current kernel/callable
+/// if not, capture the node recursively
+fn process_potential_capture(node: SafeNodeRef) -> SafeNodeRef {
+    if node.node.is_user_data() {
+        return node;
+    }
+    let cur_kernel_id = KERNEL_ID.load(std::sync::atomic::Ordering::Relaxed);
+    assert_eq!(
+        cur_kernel_id, node.kernel_id,
+        "Referencing node from another kernel!"
+    );
+    with_recorder(|r| {
+        let ptr = r as *mut _;
+        // defined in same callable, no need to capture
+        if ptr == node.recorder {
+            return node;
+        }
+        r.map_captured_vars(node)
+    })
+}
+pub(crate) fn push_recorder() {
+    let mut new = Rc::new(RefCell::new(FnRecorder::new()));
     RECORDER.with(|r| {
         let mut r = r.borrow_mut();
-        assert!(r.lock, "__current_scope must be called within a kernel");
+        let old = std::mem::replace(&mut *r, Some(new.clone()));
+        new.borrow_mut().parent = old;
+    })
+}
+pub(crate) fn pop_recorder() -> FnRecorderPtr {
+    RECORDER.with(|r| {
+        let mut r = r.borrow_mut();
+        let parent = r.as_mut().unwrap().borrow_mut().parent.take();
+        let cur = std::mem::replace(&mut *r, parent);
+        cur.unwrap()
+    })
+}
+
+pub(crate) fn with_recorder<R>(f: impl FnOnce(&mut FnRecorder) -> R) -> R {
+    RECORDER.with(|r| {
+        // amazing!
+        let mut r = r.borrow_mut();
+        let r = r
+            .as_mut()
+            .unwrap_or_else(|| panic!("Kernel recording not started"));
+        let mut r = r.borrow_mut();
+        f(&mut *r)
+    })
+}
+// Don't call this function directly unless you know what you are doing
+pub fn __current_scope<F: FnOnce(&mut IrBuilder) -> R, R>(f: F) -> R {
+    with_recorder(|r| {
         let s = &mut r.scopes;
         f(s.last_mut().unwrap())
     })
 }
 
 pub(crate) fn __invoke_callable(callable: &CallableModuleRef, args: &[NodeRef]) -> NodeRef {
-    RECORDER.with(|r| {
-        let mut r = r.borrow_mut();
+    with_recorder(|r| {
         let id = CArc::as_ptr(&callable.0) as u64;
         if let Some(c) = r.callables.get(&id) {
             assert_eq!(CArc::as_ptr(&c.0), CArc::as_ptr(&callable.0));
@@ -394,17 +507,14 @@ pub(crate) fn __check_callable(callable: &CallableModuleRef, args: &[NodeRef]) -
 
 // Don't call this function directly unless you know what you are doing
 pub fn __pop_scope() -> Pooled<BasicBlock> {
-    RECORDER.with(|r| {
-        let mut r = r.borrow_mut();
+    with_recorder(|r| {
         let s = &mut r.scopes;
         s.pop().unwrap().finish()
     })
 }
 
 pub fn __module_pools() -> &'static CArc<ModulePools> {
-    RECORDER.with(|r| {
-        let r = r.borrow();
-        assert!(r.lock, "__module_pools must be called within a kernel");
+    with_recorder(|r| {
         let pool = r.pools.as_ref().unwrap();
         unsafe { std::mem::transmute(pool) }
     })

--- a/luisa_compute/src/lang.rs
+++ b/luisa_compute/src/lang.rs
@@ -1,7 +1,6 @@
 use std::any::Any;
 use std::cell::{Cell, RefCell};
 use std::fmt::Debug;
-use std::ops::Deref;
 use std::rc::Rc;
 use std::sync::atomic::AtomicUsize;
 use std::sync::Arc;
@@ -647,7 +646,6 @@ where
     B: IndexWrite<Element = u32> + ToNode,
 {
     let index = index.as_expr().node().get();
-    let expor = expr.node().get();
     let buffer = buffer.node().get();
     let expr = expr.node().get();
     __current_scope(|b| {

--- a/luisa_compute/src/lang/control_flow.rs
+++ b/luisa_compute/src/lang/control_flow.rs
@@ -129,27 +129,25 @@ pub fn if_then_else<R: Aggregate>(
         b.if_(cond, then_block, else_block);
     });
     assert_eq!(then_nodes.len(), else_nodes.len());
-    let phis = __current_scope(|b| {
-        then_nodes
-            .iter()
-            .zip(else_nodes.iter())
-            .map(|(then, else_)| {
-                let incomings = vec![
-                    PhiIncoming {
-                        value: *then,
-                        block: then_block,
-                    },
-                    PhiIncoming {
-                        value: *else_,
-                        block: else_block,
-                    },
-                ];
-                assert_eq!(then.type_(), else_.type_());
-                let phi = b.phi(&incomings, then.type_().clone());
-                phi.into()
-            })
-            .collect::<Vec<_>>()
-    });
+    let phis = then_nodes
+        .iter()
+        .zip(else_nodes.iter())
+        .map(|(then, else_)| {
+            let incomings = vec![
+                PhiIncoming {
+                    value: *then,
+                    block: then_block,
+                },
+                PhiIncoming {
+                    value: *else_,
+                    block: else_block,
+                },
+            ];
+            assert_eq!(then.type_(), else_.type_());
+            let phi = __current_scope(|b| b.phi(&incomings, then.type_().clone()));
+            phi.into()
+        })
+        .collect::<Vec<_>>();
     R::from_vec_nodes(phis)
 }
 

--- a/luisa_compute/src/lang/control_flow.rs
+++ b/luisa_compute/src/lang/control_flow.rs
@@ -52,30 +52,29 @@ pub fn continue_() {
 }
 
 pub fn return_v<T: NodeLike>(v: T) {
-    RECORDER.with(|r| {
-        let mut r = r.borrow_mut();
+    let v = v.node().get();
+    with_recorder(|r| {
         if r.building_kernel {
             panic!("cannot return value from kernel!");
         }
         if r.callable_ret_type.is_none() {
-            r.callable_ret_type = Some(v.node().type_().clone());
+            r.callable_ret_type = Some(v.type_().clone());
         } else {
             assert!(
                 luisa_compute_ir::context::is_type_equal(
                     r.callable_ret_type.as_ref().unwrap(),
-                    v.node().type_()
+                    v.type_()
                 ),
                 "return type mismatch"
             );
         }
     });
     __current_scope(|b| {
-        b.return_(v.node());
+        b.return_(v);
     });
 }
 pub fn return_() {
-    RECORDER.with(|r| {
-        let mut r = r.borrow_mut();
+    with_recorder(|r| {
         if !r.building_kernel {
             if r.callable_ret_type.is_none() {
                 r.callable_ret_type = Some(Type::void());
@@ -97,30 +96,35 @@ pub fn if_then_else<R: Aggregate>(
     then: impl Fn() -> R,
     else_: impl Fn() -> R,
 ) -> R {
-    let cond = cond.node();
-    RECORDER.with(|r| {
-        let mut r = r.borrow_mut();
-        let pools = r.pools.clone().unwrap();
+    let cond = cond.node().get();
+    with_recorder(|r| {
+        let pools = r.pools.clone();
         let s = &mut r.scopes;
         s.push(IrBuilder::new(pools));
     });
     let then = then();
-    let then_block = RECORDER.with(|r| {
-        let mut r = r.borrow_mut();
-        let pools = r.pools.clone().unwrap();
+    let then_nodes = then
+        .to_vec_nodes()
+        .into_iter()
+        .map(|x| x.get())
+        .collect::<Vec<_>>();
+    let then_block = with_recorder(|r| {
+        let pools = r.pools.clone();
         let s = &mut r.scopes;
         let then_block = s.pop().unwrap().finish();
         s.push(IrBuilder::new(pools));
         then_block
     });
     let else_ = else_();
-    let else_block = RECORDER.with(|r| {
-        let mut r = r.borrow_mut();
+    let else_nodes = else_
+        .to_vec_nodes()
+        .into_iter()
+        .map(|x| x.get())
+        .collect::<Vec<_>>();
+    let else_block = with_recorder(|r| {
         let s = &mut r.scopes;
         s.pop().unwrap().finish()
     });
-    let then_nodes = then.to_vec_nodes();
-    let else_nodes = else_.to_vec_nodes();
     __current_scope(|b| {
         b.if_(cond, then_block, else_block);
     });
@@ -142,7 +146,7 @@ pub fn if_then_else<R: Aggregate>(
                 ];
                 assert_eq!(then.type_(), else_.type_());
                 let phi = b.phi(&incomings, then.type_().clone());
-                phi
+                phi.into()
             })
             .collect::<Vec<_>>()
     });
@@ -150,8 +154,17 @@ pub fn if_then_else<R: Aggregate>(
 }
 
 pub fn select<A: Aggregate>(mask: Expr<bool>, a: A, b: A) -> A {
-    let a_nodes = a.to_vec_nodes();
-    let b_nodes = b.to_vec_nodes();
+    let a_nodes = a
+        .to_vec_nodes()
+        .into_iter()
+        .map(|x| x.get())
+        .collect::<Vec<_>>();
+    let b_nodes = b
+        .to_vec_nodes()
+        .into_iter()
+        .map(|x| x.get())
+        .collect::<Vec<_>>();
+    let mask = mask.node().get();
     assert_eq!(a_nodes.len(), b_nodes.len());
     let mut ret = vec![];
     __current_scope(|b| {
@@ -173,12 +186,13 @@ pub fn select<A: Aggregate>(mask: Expr<bool>, a: A, b: A) -> A {
             } else {
                 ret.push(b.call(
                     Func::Select,
-                    &[mask.node(), a_node, b_node],
+                    &[mask, a_node, b_node],
                     a_node.type_().clone(),
                 ));
             }
         }
     });
+    let ret = ret.into_iter().map(|x| x.into()).collect::<Vec<_>>();
     A::from_vec_nodes(ret)
 }
 
@@ -187,33 +201,29 @@ pub fn generic_loop(
     mut body: impl FnMut(),
     mut update: impl FnMut(),
 ) {
-    RECORDER.with(|r| {
-        let mut r = r.borrow_mut();
-        let pools = r.pools.clone().unwrap();
+    with_recorder(|r| {
+        let pools = r.pools.clone();
         let s = &mut r.scopes;
         s.push(IrBuilder::new(pools));
     });
-    let cond_v = cond().node();
-    let prepare = RECORDER.with(|r| {
-        let mut r = r.borrow_mut();
-        let pools = r.pools.clone().unwrap();
+    let cond_v = cond().node().get();
+    let prepare = with_recorder(|r| {
+        let pools = r.pools.clone();
         let s = &mut r.scopes;
         let prepare = s.pop().unwrap().finish();
         s.push(IrBuilder::new(pools));
         prepare
     });
     body();
-    let body = RECORDER.with(|r| {
-        let mut r = r.borrow_mut();
-        let pools = r.pools.clone().unwrap();
+    let body = with_recorder(|r| {
+        let pools = r.pools.clone();
         let s = &mut r.scopes;
         let body = s.pop().unwrap().finish();
         s.push(IrBuilder::new(pools));
         body
     });
     update();
-    let update = RECORDER.with(|r| {
-        let mut r = r.borrow_mut();
+    let update = with_recorder(|r| {
         let s = &mut r.scopes;
         s.pop().unwrap().finish()
     });
@@ -224,18 +234,18 @@ pub fn generic_loop(
 
 pub trait ForLoopRange {
     type Element: Value;
-    fn start(&self) -> NodeRef;
-    fn end(&self) -> NodeRef;
+    fn start(&self) -> SafeNodeRef;
+    fn end(&self) -> SafeNodeRef;
     fn end_inclusive(&self) -> bool;
 }
 macro_rules! impl_range {
     ($t:ty) => {
         impl ForLoopRange for std::ops::RangeInclusive<$t> {
             type Element = $t;
-            fn start(&self) -> NodeRef {
+            fn start(&self) -> SafeNodeRef {
                 (*self.start()).expr().node()
             }
-            fn end(&self) -> NodeRef {
+            fn end(&self) -> SafeNodeRef {
                 (*self.end()).expr().node()
             }
             fn end_inclusive(&self) -> bool {
@@ -244,10 +254,10 @@ macro_rules! impl_range {
         }
         impl ForLoopRange for std::ops::RangeInclusive<Expr<$t>> {
             type Element = $t;
-            fn start(&self) -> NodeRef {
+            fn start(&self) -> SafeNodeRef {
                 self.start().node()
             }
-            fn end(&self) -> NodeRef {
+            fn end(&self) -> SafeNodeRef {
                 self.end().node()
             }
             fn end_inclusive(&self) -> bool {
@@ -256,10 +266,10 @@ macro_rules! impl_range {
         }
         impl ForLoopRange for std::ops::Range<$t> {
             type Element = $t;
-            fn start(&self) -> NodeRef {
+            fn start(&self) -> SafeNodeRef {
                 (self.start).expr().node()
             }
-            fn end(&self) -> NodeRef {
+            fn end(&self) -> SafeNodeRef {
                 (self.end).expr().node()
             }
             fn end_inclusive(&self) -> bool {
@@ -268,10 +278,10 @@ macro_rules! impl_range {
         }
         impl ForLoopRange for std::ops::Range<Expr<$t>> {
             type Element = $t;
-            fn start(&self) -> NodeRef {
+            fn start(&self) -> SafeNodeRef {
                 self.start.node()
             }
-            fn end(&self) -> NodeRef {
+            fn end(&self) -> SafeNodeRef {
                 self.end.node()
             }
             fn end_inclusive(&self) -> bool {
@@ -298,8 +308,8 @@ pub fn for_unrolled<I: IntoIterator>(iter: I, body: impl Fn(I::Item)) {
 }
 
 pub fn for_range<R: ForLoopRange>(r: R, body: impl Fn(Expr<R::Element>)) {
-    let start = r.start();
-    let end = r.end();
+    let start = r.start().get();
+    let end = r.end().get();
     let inc = |v: NodeRef| {
         __current_scope(|b| {
             let one = b.const_(Const::One(v.type_().clone()));
@@ -309,22 +319,25 @@ pub fn for_range<R: ForLoopRange>(r: R, body: impl Fn(Expr<R::Element>)) {
     let i = __current_scope(|b| b.local(start));
     generic_loop(
         || {
-            Expr::<bool>::from_node(__current_scope(|b| {
-                let i = b.call(Func::Load, &[i], i.type_().clone());
-                b.call(
-                    if r.end_inclusive() {
-                        Func::Le
-                    } else {
-                        Func::Lt
-                    },
-                    &[i, end],
-                    <bool as TypeOf>::type_(),
-                )
-            }))
+            Expr::<bool>::from_node(
+                __current_scope(|b| {
+                    let i = b.call(Func::Load, &[i], i.type_().clone());
+                    b.call(
+                        if r.end_inclusive() {
+                            Func::Le
+                        } else {
+                            Func::Lt
+                        },
+                        &[i, end],
+                        <bool as TypeOf>::type_(),
+                    )
+                })
+                .into(),
+            )
         },
         move || {
             let i = __current_scope(|b| b.call(Func::Load, &[i], i.type_().clone()));
-            body(Expr::<R::Element>::from_node(i));
+            body(Expr::<R::Element>::from_node(i.into()));
         },
         || {
             let i_old = __current_scope(|b| b.call(Func::Load, &[i], i.type_().clone()));
@@ -351,40 +364,37 @@ impl<R: Aggregate> SwitchBuilder<R> {
         SwitchBuilder {
             cases: vec![],
             default: None,
-            value: node.node(),
+            value: node.node().get(),
             _marker: PhantomData,
-            depth: RECORDER.with(|r| r.borrow().scopes.len()),
+            depth: with_recorder(|r| r.scopes.len()),
         }
     }
     pub fn case(mut self, value: i32, then: impl Fn() -> R) -> Self {
-        RECORDER.with(|r| {
-            let mut r = r.borrow_mut();
-            let pools = r.pools.clone().unwrap();
+        with_recorder(|r| {
+            let pools = r.pools.clone();
             let s = &mut r.scopes;
             assert_eq!(s.len(), self.depth);
             s.push(IrBuilder::new(pools));
         });
-        let then = then();
+        let then = then().to_vec_nodes().into_iter().map(|x| x.get()).collect();
         let block = __pop_scope();
-        self.cases.push((value, block, then.to_vec_nodes()));
+        self.cases.push((value, block, then));
         self
     }
     pub fn default(mut self, then: impl Fn() -> R) -> Self {
-        RECORDER.with(|r| {
-            let mut r = r.borrow_mut();
-            let pools = r.pools.clone().unwrap();
+        with_recorder(|r| {
+            let pools = r.pools.clone();
             let s = &mut r.scopes;
             assert_eq!(s.len(), self.depth);
             s.push(IrBuilder::new(pools));
         });
-        let then = then();
+        let then = then().to_vec_nodes().into_iter().map(|x| x.get()).collect();
         let block = __pop_scope();
-        self.default = Some((block, then.to_vec_nodes()));
+        self.default = Some((block, then));
         self
     }
     pub fn finish(self) -> R {
-        RECORDER.with(|r| {
-            let mut r = r.borrow_mut();
+        with_recorder(|r| {
             let s = &mut r.scopes;
             assert_eq!(s.len(), self.depth);
         });
@@ -404,9 +414,8 @@ impl<R: Aggregate> SwitchBuilder<R> {
         let phi_count = case_phis[0].len();
         let mut default_nodes = vec![];
         let default_block = if self.default.is_none() {
-            RECORDER.with(|r| {
-                let mut r = r.borrow_mut();
-                let pools = r.pools.clone().unwrap();
+            with_recorder(|r| {
+                let pools = r.pools.clone();
                 let s = &mut r.scopes;
                 assert_eq!(s.len(), self.depth);
                 s.push(IrBuilder::new(pools));
@@ -446,6 +455,7 @@ impl<R: Aggregate> SwitchBuilder<R> {
             let phi = __current_scope(|b| b.phi(&incomings, case_phis[0][i].type_().clone()));
             phis.push(phi);
         }
+        let phis = phis.into_iter().map(|x| x.into()).collect::<Vec<_>>();
         R::from_vec_nodes(phis)
     }
 }

--- a/luisa_compute/src/lang/functions.rs
+++ b/luisa_compute/src/lang/functions.rs
@@ -1,34 +1,31 @@
-use crate::internal_prelude::*;
+use crate::{internal_prelude::*, lang::with_recorder};
 
 use super::types::core::{Integral, Numeric};
 
 pub fn thread_id() -> Expr<Uint3> {
-    Expr::<Uint3>::from_node(__current_scope(|b| {
-        b.call(Func::ThreadId, &[], Uint3::type_())
-    }))
+    Expr::<Uint3>::from_node(
+        __current_scope(|b| b.call(Func::ThreadId, &[], Uint3::type_())).into(),
+    )
 }
 
 pub fn block_id() -> Expr<Uint3> {
-    Expr::<Uint3>::from_node(__current_scope(|b| {
-        b.call(Func::BlockId, &[], Uint3::type_())
-    }))
+    Expr::<Uint3>::from_node(__current_scope(|b| b.call(Func::BlockId, &[], Uint3::type_())).into())
 }
 
 pub fn dispatch_id() -> Expr<Uint3> {
-    Expr::<Uint3>::from_node(__current_scope(|b| {
-        b.call(Func::DispatchId, &[], Uint3::type_())
-    }))
+    Expr::<Uint3>::from_node(
+        __current_scope(|b| b.call(Func::DispatchId, &[], Uint3::type_())).into(),
+    )
 }
 
 pub fn dispatch_size() -> Expr<Uint3> {
-    Expr::<Uint3>::from_node(__current_scope(|b| {
-        b.call(Func::DispatchSize, &[], Uint3::type_())
-    }))
+    Expr::<Uint3>::from_node(
+        __current_scope(|b| b.call(Func::DispatchSize, &[], Uint3::type_())).into(),
+    )
 }
 
 fn check_block_size_for_cpu() {
-    RECORDER.with(|r| {
-        let r = r.borrow();
+    with_recorder(|r| {
         assert!(
             r.block_size.is_some(),
             "CPU backend only support block operations on block size 1"
@@ -52,148 +49,131 @@ pub fn sync_block() {
 }
 
 pub fn warp_is_first_active_lane() -> Expr<bool> {
-    Expr::<bool>::from_node(__current_scope(|b| {
-        b.call(Func::WarpIsFirstActiveLane, &[], bool::type_())
-    }))
+    Expr::<bool>::from_node(
+        __current_scope(|b| b.call(Func::WarpIsFirstActiveLane, &[], bool::type_())).into(),
+    )
 }
 pub fn warp_active_all_equal(v: Expr<impl Linear>) -> Expr<bool> {
-    Expr::<bool>::from_node(__current_scope(|b| {
-        b.call(
-            Func::WarpActiveAllEqual,
-            &[v.node()],
-            <bool as TypeOf>::type_(),
-        )
-    }))
+    let v = v.node().get();
+    Expr::<bool>::from_node(
+        __current_scope(|b| b.call(Func::WarpActiveAllEqual, &[v], <bool as TypeOf>::type_()))
+            .into(),
+    )
 }
 pub fn warp_active_bit_and<T: Linear>(v: Expr<T>) -> Expr<T>
 where
     T::Scalar: Integral + Numeric,
 {
-    Expr::<T>::from_node(__current_scope(|b| {
-        b.call(
-            Func::WarpActiveBitAnd,
-            &[v.node()],
-            <bool as TypeOf>::type_(),
-        )
-    }))
+    let v = v.node().get();
+    Expr::<T>::from_node(
+        __current_scope(|b| b.call(Func::WarpActiveBitAnd, &[v], <bool as TypeOf>::type_())).into(),
+    )
 }
 
 pub fn warp_active_bit_or<T: Linear>(v: Expr<T>) -> Expr<T>
 where
     T::Scalar: Integral + Numeric,
 {
-    Expr::<T>::from_node(__current_scope(|b| {
-        b.call(
-            Func::WarpActiveBitOr,
-            &[v.node()],
-            <bool as TypeOf>::type_(),
-        )
-    }))
+    let v = v.node().get();
+    Expr::<T>::from_node(
+        __current_scope(|b| b.call(Func::WarpActiveBitOr, &[v], <bool as TypeOf>::type_())).into(),
+    )
 }
 
 pub fn warp_active_bit_xor<T: Linear>(v: Expr<T>) -> Expr<T>
 where
     T::Scalar: Integral + Numeric,
 {
-    Expr::<T>::from_node(__current_scope(|b| {
-        b.call(
-            Func::WarpActiveBitXor,
-            &[v.node()],
-            <bool as TypeOf>::type_(),
-        )
-    }))
+    let v = v.node().get();
+    Expr::<T>::from_node(
+        __current_scope(|b| b.call(Func::WarpActiveBitXor, &[v], <bool as TypeOf>::type_())).into(),
+    )
 }
 
 pub fn warp_active_count_bits(v: impl AsExpr<Value = bool>) -> Expr<u32> {
-    Expr::<u32>::from_node(__current_scope(|b| {
-        b.call(
-            Func::WarpActiveCountBits,
-            &[v.as_expr().node()],
-            <u32 as TypeOf>::type_(),
-        )
-    }))
+    let v = v.as_expr().node().get();
+    Expr::<u32>::from_node(
+        __current_scope(|b| b.call(Func::WarpActiveCountBits, &[v], <u32 as TypeOf>::type_()))
+            .into(),
+    )
 }
 pub fn warp_active_max<T: Linear>(v: Expr<T>) -> Expr<T::Scalar> {
-    Expr::<T::Scalar>::from_node(__current_scope(|b| {
-        b.call(Func::WarpActiveMax, &[v.node()], <T::Scalar>::type_())
-    }))
+    let v = v.node().get();
+    Expr::<T::Scalar>::from_node(
+        __current_scope(|b| b.call(Func::WarpActiveMax, &[v], <T::Scalar>::type_())).into(),
+    )
 }
 pub fn warp_active_min<T: Linear>(v: Expr<T>) -> Expr<T::Scalar> {
-    Expr::<T::Scalar>::from_node(__current_scope(|b| {
-        b.call(Func::WarpActiveMin, &[v.node()], <T::Scalar>::type_())
-    }))
+    let v = v.node().get();
+    Expr::<T::Scalar>::from_node(
+        __current_scope(|b| b.call(Func::WarpActiveMin, &[v], <T::Scalar>::type_())).into(),
+    )
 }
 pub fn warp_active_product<T: Linear>(v: Expr<T>) -> Expr<T::Scalar> {
-    Expr::<T::Scalar>::from_node(__current_scope(|b| {
-        b.call(Func::WarpActiveProduct, &[v.node()], <T::Scalar>::type_())
-    }))
+    let v = v.node().get();
+    Expr::<T::Scalar>::from_node(
+        __current_scope(|b| b.call(Func::WarpActiveProduct, &[v], <T::Scalar>::type_())).into(),
+    )
 }
 pub fn warp_active_sum<T: Linear>(v: Expr<T>) -> Expr<T::Scalar> {
-    Expr::<T::Scalar>::from_node(__current_scope(|b| {
-        b.call(Func::WarpActiveSum, &[v.node()], <T::Scalar>::type_())
-    }))
+    let v = v.node().get();
+    Expr::<T::Scalar>::from_node(
+        __current_scope(|b| b.call(Func::WarpActiveSum, &[v], <T::Scalar>::type_())).into(),
+    )
 }
 pub fn warp_active_all(v: Expr<bool>) -> Expr<bool> {
-    Expr::<bool>::from_node(__current_scope(|b| {
-        b.call(Func::WarpActiveAll, &[v.node()], <bool as TypeOf>::type_())
-    }))
+    let v = v.node().get();
+    Expr::<bool>::from_node(
+        __current_scope(|b| b.call(Func::WarpActiveAll, &[v], <bool as TypeOf>::type_())).into(),
+    )
 }
 pub fn warp_active_any(v: Expr<bool>) -> Expr<bool> {
-    Expr::<bool>::from_node(__current_scope(|b| {
-        b.call(Func::WarpActiveAny, &[v.node()], <bool as TypeOf>::type_())
-    }))
+    let v = v.node().get();
+    Expr::<bool>::from_node(
+        __current_scope(|b| b.call(Func::WarpActiveAny, &[v], <bool as TypeOf>::type_())).into(),
+    )
 }
 pub fn warp_active_bit_mask() -> Expr<Uint4> {
-    Expr::<Uint4>::from_node(__current_scope(|b| {
-        b.call(Func::WarpActiveBitMask, &[], <Uint4 as TypeOf>::type_())
-    }))
+    Expr::<Uint4>::from_node(
+        __current_scope(|b| b.call(Func::WarpActiveBitMask, &[], <Uint4 as TypeOf>::type_()))
+            .into(),
+    )
 }
 pub fn warp_prefix_count_bits(v: Expr<bool>) -> Expr<u32> {
-    Expr::<u32>::from_node(__current_scope(|b| {
-        b.call(
-            Func::WarpPrefixCountBits,
-            &[v.node()],
-            <u32 as TypeOf>::type_(),
-        )
-    }))
+    let v = v.node().get();
+    Expr::<u32>::from_node(
+        __current_scope(|b| b.call(Func::WarpPrefixCountBits, &[v], <u32 as TypeOf>::type_()))
+            .into(),
+    )
 }
 pub fn warp_prefix_sum_exclusive<T: Linear>(v: Expr<T>) -> Expr<T> {
-    Expr::<T>::from_node(__current_scope(|b| {
-        b.call(Func::WarpPrefixSum, &[v.node()], v.node().type_().clone())
-    }))
+    let v = v.node().get();
+    Expr::<T>::from_node(
+        __current_scope(|b| b.call(Func::WarpPrefixSum, &[v], v.type_().clone())).into(),
+    )
 }
 pub fn warp_prefix_product_exclusive<T: Linear>(v: Expr<T>) -> Expr<T> {
-    Expr::<T>::from_node(__current_scope(|b| {
-        b.call(
-            Func::WarpPrefixProduct,
-            &[v.node()],
-            v.node().type_().clone(),
-        )
-    }))
+    let v = v.node().get();
+    Expr::<T>::from_node(
+        __current_scope(|b| b.call(Func::WarpPrefixProduct, &[v], v.type_().clone())).into(),
+    )
 }
 // TODO: Difference between `Linear` and BuiltinVarTrait?
 pub fn warp_read_lane_at<T: Linear>(v: Expr<T>, index: impl AsExpr<Value = u32>) -> Expr<T> {
-    let index = index.as_expr();
-    Expr::<T>::from_node(__current_scope(|b| {
-        b.call(
-            Func::WarpReadLaneAt,
-            &[v.node(), index.node()],
-            v.node().type_().clone(),
-        )
-    }))
+    let index = index.as_expr().node().get();
+    let v = v.node().get();
+    Expr::<T>::from_node(
+        __current_scope(|b| b.call(Func::WarpReadLaneAt, &[v, index], v.type_().clone())).into(),
+    )
 }
 pub fn warp_read_first_active_lane<T: Linear>(v: Expr<T>) -> Expr<T> {
-    Expr::<T>::from_node(__current_scope(|b| {
-        b.call(
-            Func::WarpReadFirstLane,
-            &[v.node()],
-            v.node().type_().clone(),
-        )
-    }))
+    let v = v.node().get();
+    Expr::<T>::from_node(
+        __current_scope(|b| b.call(Func::WarpReadFirstLane, &[v], v.type_().clone())).into(),
+    )
 }
 pub fn set_block_size(size: [u32; 3]) {
-    RECORDER.with(|r| {
-        let mut r = r.borrow_mut();
+    with_recorder(|r| {
         assert!(
             r.building_kernel,
             "set_block_size cannot be called in callable!"
@@ -205,8 +185,7 @@ pub fn set_block_size(size: [u32; 3]) {
 }
 
 pub fn block_size() -> Expr<Uint3> {
-    RECORDER.with(|r| {
-        let r = r.borrow();
+    with_recorder(|r| {
         let s = r.block_size.unwrap_or_else(|| panic!("Block size not set"));
         Uint3::new(s[0], s[1], s[2]).expr()
     })
@@ -214,7 +193,8 @@ pub fn block_size() -> Expr<Uint3> {
 
 pub unsafe fn bitcast<From: Value, To: Value>(expr: Expr<From>) -> Expr<To> {
     assert_eq!(std::mem::size_of::<From>(), std::mem::size_of::<To>());
-    Expr::<To>::from_node(__current_scope(|b| {
-        b.call(Func::Bitcast, &[expr.node()], <To as TypeOf>::type_())
-    }))
+    let expr = expr.node().get();
+    Expr::<To>::from_node(
+        __current_scope(|b| b.call(Func::Bitcast, &[expr], <To as TypeOf>::type_())).into(),
+    )
 }

--- a/luisa_compute/src/lang/ops/impls.rs
+++ b/luisa_compute/src/lang/ops/impls.rs
@@ -224,10 +224,14 @@ where
         self.clone().mul(self.clone()).mul(self.clone())
     }
     fn recip(&self) -> Self {
-        <Self as FromNode>::from_node(__current_scope(|b| {
-            let one = b.const_(Const::One(<X as TypeOf>::type_()));
-            b.call(Func::Div, &[one, self.node()], <X as TypeOf>::type_())
-        }))
+        let self_node = self.node().get();
+        <Self as FromNode>::from_node(
+            __current_scope(|b| {
+                let one = b.const_(Const::One(<X as TypeOf>::type_()));
+                b.call(Func::Div, &[one, self_node], <X as TypeOf>::type_())
+            })
+            .into(),
+        )
     }
     fn sin_cos(&self) -> (Self, Self) {
         (self.sin(), self.cos())

--- a/luisa_compute/src/lang/types.rs
+++ b/luisa_compute/src/lang/types.rs
@@ -4,7 +4,7 @@ use std::ops::Deref;
 use crate::internal_prelude::*;
 
 use super::soa::SoaMetadata;
-use super::{process_potential_capture, with_recorder};
+use super::with_recorder;
 
 pub mod alignment;
 pub mod array;

--- a/luisa_compute/src/lang/types/array.rs
+++ b/luisa_compute/src/lang/types/array.rs
@@ -343,7 +343,7 @@ impl<T: Value> VLArrayExpr<T> {
                 })),
             )
         });
-        Self::from_node(node)
+        Self::from_node(node.into())
     }
     pub fn len(&self) -> usize {
         match self.node.get().type_().as_ref() {

--- a/luisa_compute/src/lang/types/array.rs
+++ b/luisa_compute/src/lang/types/array.rs
@@ -11,9 +11,9 @@ impl<T: Value, const N: usize> Value for [T; N] {
 }
 impl<T: Value, const N: usize> ArrayNewExpr<T, N> for [T; N] {
     fn from_elems_expr(elems: [Expr<T>; N]) -> Expr<Self> {
-        let node =
-            __current_scope(|b| b.call(Func::Array, &elems.map(|e| e.node()), <[T; N]>::type_()));
-        Expr::<Self>::from_node(node)
+        let elems = elems.map(|e| e.node().get());
+        let node = __current_scope(|b| b.call(Func::Array, &elems, <[T; N]>::type_()));
+        Expr::<Self>::from_node(node.into())
     }
 }
 
@@ -85,10 +85,11 @@ impl<T: Value, const N: usize, X: IntoIndex> Index<X> for ArrayExpr<T, N> {
         if need_runtime_check() {
             check_index_lt_usize(i, N);
         }
-
-        Expr::<T>::from_node(__current_scope(|b| {
-            b.call(Func::ExtractElement, &[self.0.node, i.node()], T::type_())
-        }))
+        let i = i.node().get();
+        let self_node = self.0.node().get();
+        Expr::<T>::from_node(
+            __current_scope(|b| b.call(Func::ExtractElement, &[self_node, i], T::type_())).into(),
+        )
         ._ref()
     }
 }
@@ -101,19 +102,18 @@ impl<T: Value, const N: usize, X: IntoIndex> Index<X> for ArrayAtomicRef<T, N> {
         if need_runtime_check() {
             check_index_lt_usize(i, N);
         }
-
-        AtomicRef::<T>::from_node(__current_scope(|b| {
-            let inst = self.0.node.get().instruction.as_ref();
-            let mut args = match inst {
-                Instruction::Call(f, args) => match f {
-                    Func::AtomicRef => args.to_vec(),
-                    _ => unreachable!(),
-                },
+        let inst = self.0.node.get().get().instruction.as_ref();
+        let mut args = match inst {
+            Instruction::Call(f, args) => match f {
+                Func::AtomicRef => args.to_vec(),
                 _ => unreachable!(),
-            };
-            args.push(i.node());
-            b.call_no_append(Func::AtomicRef, &args, T::type_())
-        }))
+            },
+            _ => unreachable!(),
+        };
+        args.push(i.node().get());
+        AtomicRef::<T>::from_node(
+            __current_scope(|b| b.call_no_append(Func::AtomicRef, &args, T::type_())).into(),
+        )
         ._ref()
     }
 }
@@ -130,9 +130,9 @@ macro_rules! impl_array_vec_conversion{
             where T: vector::VectorAlign<$N>,
         {
             fn from(vec:Expr<Vector<T,$N>>)->Self{
-                let elems = (0..$N).map(|i| __extract::<T>(vec.node(), i)).collect::<Vec<_>>();
+                let elems = (0..$N).map(|i| __extract::<T>(vec.node().get(), i)).collect::<Vec<_>>();
                 let node = __current_scope(|b| b.call(Func::Array, &elems, <[T;$N]>::type_()));
-                Self::from_node(node)
+                Self::from_node(node.into())
             }
         }
     }
@@ -144,9 +144,11 @@ impl<T: Value, const N: usize> IndexRead for Expr<[T; N]> {
         if need_runtime_check() {
             check_index_lt_usize(i, N);
         }
-        Expr::<T>::from_node(__current_scope(|b| {
-            b.call(Func::ExtractElement, &[self.node(), i.node()], T::type_())
-        }))
+        let self_node = self.node().get();
+        let i = i.node().get();
+        Expr::<T>::from_node(
+            __current_scope(|b| b.call(Func::ExtractElement, &[self_node, i], T::type_())).into(),
+        )
     }
 }
 impl<T: Value, const N: usize> IndexRead for Var<[T; N]> {
@@ -156,10 +158,15 @@ impl<T: Value, const N: usize> IndexRead for Var<[T; N]> {
         if need_runtime_check() {
             check_index_lt_usize(i, N);
         }
-        Expr::<T>::from_node(__current_scope(|b| {
-            let gep = b.call(Func::GetElementPtr, &[self.node(), i.node()], T::type_());
-            b.load(gep)
-        }))
+        let self_node = self.node().get();
+        let i = i.node().get();
+        Expr::<T>::from_node(
+            __current_scope(|b| {
+                let gep = b.call(Func::GetElementPtr, &[self_node, i], T::type_());
+                b.load(gep)
+            })
+            .into(),
+        )
     }
 }
 impl<T: Value, const N: usize> IndexWrite for Var<[T; N]> {
@@ -169,9 +176,12 @@ impl<T: Value, const N: usize> IndexWrite for Var<[T; N]> {
         if need_runtime_check() {
             check_index_lt_usize(i, N);
         }
+        let self_node = self.node().get();
+        let i = i.node().get();
+        let value = value.node().get();
         __current_scope(|b| {
-            let gep = b.call(Func::GetElementPtr, &[self.node(), i.node()], T::type_());
-            b.update(gep, value.node());
+            let gep = b.call(Func::GetElementPtr, &[self_node, i], T::type_());
+            b.update(gep, value);
         });
     }
 }
@@ -181,11 +191,11 @@ impl_array_vec_conversion!(4, 0, 1, 2, 3,);
 #[derive(Clone, Copy, Debug)]
 pub struct VLArrayExpr<T: Value> {
     marker: PhantomData<T>,
-    pub(super) node: NodeRef,
+    pub(super) node: SafeNodeRef,
 }
 
 impl<T: Value> FromNode for VLArrayExpr<T> {
-    fn from_node(node: NodeRef) -> Self {
+    fn from_node(node: SafeNodeRef) -> Self {
         Self {
             marker: PhantomData,
             node,
@@ -194,16 +204,16 @@ impl<T: Value> FromNode for VLArrayExpr<T> {
 }
 
 impl<T: Value> ToNode for VLArrayExpr<T> {
-    fn node(&self) -> NodeRef {
+    fn node(&self) -> SafeNodeRef {
         self.node
     }
 }
 
 impl<T: Value> Aggregate for VLArrayExpr<T> {
-    fn to_nodes(&self, nodes: &mut Vec<NodeRef>) {
+    fn to_nodes(&self, nodes: &mut Vec<SafeNodeRef>) {
         nodes.push(self.node);
     }
-    fn from_nodes<I: Iterator<Item = NodeRef>>(iter: &mut I) -> Self {
+    fn from_nodes<I: Iterator<Item = SafeNodeRef>>(iter: &mut I) -> Self {
         Self::from_node(iter.next().unwrap())
     }
 }
@@ -211,11 +221,11 @@ impl<T: Value> Aggregate for VLArrayExpr<T> {
 #[derive(Clone, Copy, Debug)]
 pub struct VLArrayVar<T: Value> {
     marker: PhantomData<T>,
-    node: NodeRef,
+    node: SafeNodeRef,
 }
 
 impl<T: Value> FromNode for VLArrayVar<T> {
-    fn from_node(node: NodeRef) -> Self {
+    fn from_node(node: SafeNodeRef) -> Self {
         Self {
             marker: PhantomData,
             node,
@@ -224,16 +234,16 @@ impl<T: Value> FromNode for VLArrayVar<T> {
 }
 
 impl<T: Value> ToNode for VLArrayVar<T> {
-    fn node(&self) -> NodeRef {
+    fn node(&self) -> SafeNodeRef {
         self.node
     }
 }
 
 impl<T: Value> Aggregate for VLArrayVar<T> {
-    fn to_nodes(&self, nodes: &mut Vec<NodeRef>) {
+    fn to_nodes(&self, nodes: &mut Vec<SafeNodeRef>) {
         nodes.push(self.node);
     }
-    fn from_nodes<I: Iterator<Item = NodeRef>>(iter: &mut I) -> Self {
+    fn from_nodes<I: Iterator<Item = SafeNodeRef>>(iter: &mut I) -> Self {
         Self::from_node(iter.next().unwrap())
     }
 }
@@ -244,11 +254,12 @@ impl<T: Value> IndexRead for VLArrayVar<T> {
         if need_runtime_check() {
             check_index_lt_usize(i, self.len());
         }
-
+        let self_node = self.node.get();
+        let i = i.node().get();
         Expr::<T>::from_node(__current_scope(|b| {
-            let gep = b.call(Func::GetElementPtr, &[self.node, i.node()], T::type_());
+            let gep = b.call(Func::GetElementPtr, &[self_node, i], T::type_());
             b.call(Func::Load, &[gep], T::type_())
-        }))
+        }).into())
     }
 }
 impl<T: Value> IndexWrite for VLArrayVar<T> {
@@ -259,43 +270,51 @@ impl<T: Value> IndexWrite for VLArrayVar<T> {
         if need_runtime_check() {
             check_index_lt_usize(i, self.len());
         }
-
+        let self_node = self.node.get();
+        let i = i.node().get();
+        let value = value.node().get();
         __current_scope(|b| {
-            let gep = b.call(Func::GetElementPtr, &[self.node, i.node()], T::type_());
-            b.update(gep, value.node());
+            let gep = b.call(Func::GetElementPtr, &[self_node, i], T::type_());
+            b.update(gep, value);
         });
     }
 }
 impl<T: Value> VLArrayVar<T> {
     pub fn len_expr(&self) -> Expr<u64> {
-        match self.node.type_().as_ref() {
+        match self.node.get().type_().as_ref() {
             Type::Array(ArrayType { element: _, length }) => (*length as u64).expr(),
             _ => unreachable!(),
         }
     }
     pub fn len(&self) -> usize {
-        match self.node.type_().as_ref() {
+        match self.node.get().type_().as_ref() {
             Type::Array(ArrayType { element: _, length }) => *length,
             _ => unreachable!(),
         }
     }
     pub fn load(&self) -> VLArrayExpr<T> {
-        VLArrayExpr::from_node(__current_scope(|b| {
-            b.call(Func::Load, &[self.node], self.node.type_().clone())
-        }))
+        let node = self.node.get();
+        VLArrayExpr::from_node(
+            __current_scope(|b| b.call(Func::Load, &[node], node.type_().clone())).into(),
+        )
     }
     pub fn store(&self, value: VLArrayExpr<T>) {
+        let node = self.node.get();
+        let value = value.node.get();
         __current_scope(|b| {
-            b.update(self.node, value.node);
+            b.update(node, value);
         });
     }
     pub fn zero(length: usize) -> Self {
-        FromNode::from_node(__current_scope(|b| {
-            b.local_zero_init(ir::context::register_type(Type::Array(ArrayType {
-                element: T::type_(),
-                length,
-            })))
-        }))
+        FromNode::from_node(
+            __current_scope(|b| {
+                b.local_zero_init(ir::context::register_type(Type::Array(ArrayType {
+                    element: T::type_(),
+                    length,
+                })))
+            })
+            .into(),
+        )
     }
 }
 impl<T: Value> IndexRead for VLArrayExpr<T> {
@@ -305,9 +324,11 @@ impl<T: Value> IndexRead for VLArrayExpr<T> {
         if need_runtime_check() {
             check_index_lt_usize(i, self.len());
         }
+        let node = self.node.get();
+        let i = i.node().get();
         Expr::<T>::from_node(__current_scope(|b| {
-            b.call(Func::ExtractElement, &[self.node, i.node()], T::type_())
-        }))
+            b.call(Func::ExtractElement, &[node, i], T::type_())
+        }).into())
     }
 }
 impl<T: Value> VLArrayExpr<T> {
@@ -325,13 +346,13 @@ impl<T: Value> VLArrayExpr<T> {
         Self::from_node(node)
     }
     pub fn len(&self) -> usize {
-        match self.node.type_().as_ref() {
+        match self.node.get().type_().as_ref() {
             Type::Array(ArrayType { element: _, length }) => *length,
             _ => unreachable!(),
         }
     }
     pub fn len_expr(&self) -> Expr<u64> {
-        match self.node.type_().as_ref() {
+        match self.node.get().type_().as_ref() {
             Type::Array(ArrayType { element: _, length }) => (*length as u64).expr(),
             _ => unreachable!(),
         }

--- a/luisa_compute/src/lang/types/core.rs
+++ b/luisa_compute/src/lang/types/core.rs
@@ -267,7 +267,7 @@ impl<T: Primitive> Value for T {
 
     fn expr(self) -> Expr<Self> {
         let node = __current_scope(|s| -> NodeRef { s.const_(self.const_()) });
-        Expr::<Self>::from_node(node)
+        Expr::<Self>::from_node(node.into())
     }
 }
 impl<T: Primitive> SoaValue for T
@@ -290,44 +290,44 @@ macro_rules! impl_atomic {
                 desired: impl AsExpr<Value = $t>,
             ) -> Expr<$t> {
                 lower_atomic_ref(
-                    self.node(),
+                    self.node().get(),
                     Func::AtomicCompareExchange,
-                    &[expected.as_expr().node(), desired.as_expr().node()],
+                    &[expected.as_expr().node().get(), desired.as_expr().node().get()],
                 )
             }
             pub fn exchange(&self, operand: impl AsExpr<Value = $t>) -> Expr<$t> {
                 lower_atomic_ref(
-                    self.node(),
+                    self.node().get(),
                     Func::AtomicExchange,
-                    &[operand.as_expr().node()],
+                    &[operand.as_expr().node().get()],
                 )
             }
             pub fn fetch_add(&self, operand: impl AsExpr<Value = $t>) -> Expr<$t> {
                 lower_atomic_ref(
-                    self.node(),
+                    self.node().get(),
                     Func::AtomicFetchAdd,
-                    &[operand.as_expr().node()],
+                    &[operand.as_expr().node().get()],
                 )
             }
             pub fn fetch_sub(&self, operand: impl AsExpr<Value = $t>) -> Expr<$t> {
                 lower_atomic_ref(
-                    self.node(),
+                    self.node().get(),
                     Func::AtomicFetchSub,
-                    &[operand.as_expr().node()],
+                    &[operand.as_expr().node().get()],
                 )
             }
             pub fn fetch_min(&self, operand: impl AsExpr<Value = $t>) -> Expr<$t> {
                 lower_atomic_ref(
-                    self.node(),
+                    self.node().get(),
                     Func::AtomicFetchMin,
-                    &[operand.as_expr().node()],
+                    &[operand.as_expr().node().get()],
                 )
             }
             pub fn fetch_max(&self, operand: impl AsExpr<Value = $t>) -> Expr<$t> {
                 lower_atomic_ref(
-                    self.node(),
+                    self.node().get(),
                     Func::AtomicFetchMax,
-                    &[operand.as_expr().node()],
+                    &[operand.as_expr().node().get()],
                 )
             }
         }
@@ -338,23 +338,23 @@ macro_rules! impl_atomic_bit {
         impl AtomicRef<$t> {
             pub fn fetch_and(&self, operand: impl AsExpr<Value = $t>) -> Expr<$t> {
                 lower_atomic_ref(
-                    self.node(),
+                    self.node().get(),
                     Func::AtomicFetchAnd,
-                    &[operand.as_expr().node()],
+                    &[operand.as_expr().node().get()],
                 )
             }
             pub fn fetch_or(&self, operand: impl AsExpr<Value = $t>) -> Expr<$t> {
                 lower_atomic_ref(
-                    self.node(),
+                    self.node().get(),
                     Func::AtomicFetchOr,
-                    &[operand.as_expr().node()],
+                    &[operand.as_expr().node().get()],
                 )
             }
             pub fn fetch_xor(&self, operand: impl AsExpr<Value = $t>) -> Expr<$t> {
                 lower_atomic_ref(
-                    self.node(),
+                    self.node().get(),
                     Func::AtomicFetchXor,
-                    &[operand.as_expr().node()],
+                    &[operand.as_expr().node().get()],
                 )
             }
         }
@@ -381,7 +381,7 @@ fn lower_atomic_ref<T: Value>(node: NodeRef, op: Func, args: &[NodeRef]) -> Expr
                     .collect::<Vec<_>>();
                 Expr::<T>::from_node(__current_scope(|b| {
                     b.call(op, &new_args, <T as TypeOf>::type_())
-                }))
+                }).into())
             }
             _ => unreachable!("{:?}", inst),
         },

--- a/luisa_compute/src/lang/types/dynamic.rs
+++ b/luisa_compute/src/lang/types/dynamic.rs
@@ -6,7 +6,7 @@ use std::rc::Rc;
 
 #[derive(Clone, Copy)]
 pub struct DynExpr {
-    node: NodeRef,
+    node: SafeNodeRef,
 }
 
 impl<V: Value> From<Expr<V>> for DynExpr {
@@ -23,7 +23,7 @@ impl<V: Value> From<Var<V>> for DynVar {
 
 impl DynExpr {
     pub fn downcast<T: Value>(&self) -> Option<Expr<T>> {
-        if ir::context::is_type_equal(self.node.type_(), &T::type_()) {
+        if ir::context::is_type_equal(self.node.get().type_(), &T::type_()) {
             Some(Expr::<T>::from_node(self.node))
         } else {
             None
@@ -34,7 +34,7 @@ impl DynExpr {
             panic!(
                 "DynExpr::get: type mismatch: expected {}, got {}",
                 std::any::type_name::<T>(),
-                self.node.type_().to_string()
+                self.node.get().type_().to_string()
             )
         })
     }
@@ -43,7 +43,7 @@ impl DynExpr {
             element: T::type_(),
             length: len,
         }));
-        if ir::context::is_type_equal(self.node.type_(), &array_type) {
+        if ir::context::is_type_equal(self.node.get().type_(), &array_type) {
             Some(VLArrayExpr::<T>::from_node(self.node))
         } else {
             None
@@ -58,7 +58,7 @@ impl DynExpr {
             panic!(
                 "DynExpr::get: type mismatch: expected {}, got {}",
                 array_type,
-                self.node.type_().to_string()
+                self.node.get().type_().to_string()
             )
         })
     }
@@ -71,19 +71,19 @@ impl CallableParameter for DynExpr {
     fn def_param(arg: Option<Rc<dyn Any>>, builder: &mut KernelBuilder) -> Self {
         let arg = arg.unwrap_or_else(|| panic!("DynExpr should be used in DynCallable only!"));
         let arg = arg.downcast_ref::<Self>().unwrap();
-        let node = builder.arg(arg.node.type_().clone(), true);
+        let node = builder.arg(arg.node.get().type_().clone(), true).into();
         Self { node }
     }
     fn encode(&self, encoder: &mut CallableArgEncoder) {
-        encoder.args.push(self.node)
+        encoder.args.push(self.node.get())
     }
 }
 
 impl Aggregate for DynExpr {
-    fn to_nodes(&self, nodes: &mut Vec<NodeRef>) {
+    fn to_nodes(&self, nodes: &mut Vec<SafeNodeRef>) {
         nodes.push(self.node)
     }
-    fn from_nodes<I: Iterator<Item = NodeRef>>(iter: &mut I) -> Self {
+    fn from_nodes<I: Iterator<Item = SafeNodeRef>>(iter: &mut I) -> Self {
         Self {
             node: iter.next().unwrap(),
         }
@@ -91,34 +91,35 @@ impl Aggregate for DynExpr {
 }
 
 impl FromNode for DynExpr {
-    fn from_node(node: NodeRef) -> Self {
+    fn from_node(node: SafeNodeRef) -> Self {
         Self { node }
     }
 }
 
 impl ToNode for DynExpr {
-    fn node(&self) -> NodeRef {
+    fn node(&self) -> SafeNodeRef {
         self.node
     }
 }
 
 unsafe impl CallableRet for DynExpr {
     fn _return(&self) -> CArc<Type> {
+        let node = self.node.get();
         __current_scope(|b| {
-            b.return_(self.node);
+            b.return_(node);
         });
-        self.node.type_().clone()
+        self.node.get().type_().clone()
     }
     fn _from_return(node: NodeRef) -> Self {
-        Self::from_node(node)
+        Self::from_node(node.into())
     }
 }
 
 impl Aggregate for DynVar {
-    fn to_nodes(&self, nodes: &mut Vec<NodeRef>) {
+    fn to_nodes(&self, nodes: &mut Vec<SafeNodeRef>) {
         nodes.push(self.node)
     }
-    fn from_nodes<I: Iterator<Item = NodeRef>>(iter: &mut I) -> Self {
+    fn from_nodes<I: Iterator<Item = SafeNodeRef>>(iter: &mut I) -> Self {
         Self {
             node: iter.next().unwrap(),
         }
@@ -126,37 +127,37 @@ impl Aggregate for DynVar {
 }
 
 impl FromNode for DynVar {
-    fn from_node(node: NodeRef) -> Self {
+    fn from_node(node: SafeNodeRef) -> Self {
         Self { node }
     }
 }
 
 impl ToNode for DynVar {
-    fn node(&self) -> NodeRef {
+    fn node(&self) -> SafeNodeRef {
         self.node
     }
 }
 
 #[derive(Clone, Copy)]
 pub struct DynVar {
-    node: NodeRef,
+    node: SafeNodeRef,
 }
 
 impl CallableParameter for DynVar {
     fn def_param(arg: Option<Rc<dyn Any>>, builder: &mut KernelBuilder) -> Self {
         let arg = arg.unwrap_or_else(|| panic!("DynVar should be used in DynCallable only!"));
         let arg = arg.downcast_ref::<Self>().unwrap();
-        let node = builder.arg(arg.node.type_().clone(), false);
+        let node = builder.arg(arg.node.get().type_().clone(), false).into();
         Self { node }
     }
     fn encode(&self, encoder: &mut CallableArgEncoder) {
-        encoder.args.push(self.node)
+        encoder.args.push(self.node.get())
     }
 }
 
 impl DynVar {
     pub fn downcast<T: Value>(&self) -> Option<Var<T>> {
-        if ir::context::is_type_equal(self.node.type_(), &T::type_()) {
+        if ir::context::is_type_equal(self.node.get().type_(), &T::type_()) {
             Some(Var::<T>::from_node(self.node))
         } else {
             None
@@ -167,7 +168,7 @@ impl DynVar {
             panic!(
                 "DynVar::get: type mismatch: expected {}, got {}",
                 std::any::type_name::<T>(),
-                self.node.type_().to_string()
+                self.node.get().type_().to_string()
             )
         })
     }
@@ -176,7 +177,7 @@ impl DynVar {
             element: T::type_(),
             length: len,
         }));
-        if ir::context::is_type_equal(self.node.type_(), &array_type) {
+        if ir::context::is_type_equal(self.node.get().type_(), &array_type) {
             Some(VLArrayVar::<T>::from_node(self.node))
         } else {
             None
@@ -191,17 +192,20 @@ impl DynVar {
             panic!(
                 "DynExpr::get: type mismatch: expected {}, got {}",
                 array_type,
-                self.node.type_().to_string()
+                self.node.get().type_().to_string()
             )
         })
     }
     pub fn load(&self) -> DynExpr {
+        let self_node = self.node.get();
         DynExpr {
-            node: __current_scope(|b| b.call(Func::Load, &[self.node], self.node.type_().clone())),
+            node: __current_scope(|b| b.call(Func::Load, &[self_node], self_node.type_().clone())).into(),
         }
     }
     pub fn store(&self, value: &DynExpr) {
-        __current_scope(|b| b.update(self.node, value.node));
+        let self_node = self.node.get();
+        let value = value.node.get();
+        __current_scope(|b| b.update(self_node, value));
     }
     pub fn zero<T: Value>() -> Self {
         let v = Var::<T>::zeroed();

--- a/luisa_compute/src/lang/types/vector.rs
+++ b/luisa_compute/src/lang/types/vector.rs
@@ -46,9 +46,9 @@ pub struct Vector<T: VectorAlign<N>, const N: usize> {
 #[derive(Copy, Clone)]
 pub struct VectorExprData<T: VectorAlign<N>, const N: usize>([Expr<T>; N]);
 impl<T: VectorAlign<N>, const N: usize> FromNode for VectorExprData<T, N> {
-    fn from_node(node: NodeRef) -> Self {
+    fn from_node(node: SafeNodeRef) -> Self {
         Self(std::array::from_fn(|i| {
-            FromNode::from_node(__extract::<T>(node, i))
+            FromNode::from_node(__extract::<T>(node.get(), i).into())
         }))
     }
 }
@@ -56,9 +56,9 @@ impl<T: VectorAlign<N>, const N: usize> FromNode for VectorExprData<T, N> {
 #[derive(Copy, Clone)]
 pub struct VectorVarData<T: VectorAlign<N>, const N: usize>([Var<T>; N]);
 impl<T: VectorAlign<N>, const N: usize> FromNode for VectorVarData<T, N> {
-    fn from_node(node: NodeRef) -> Self {
+    fn from_node(node: SafeNodeRef) -> Self {
         Self(std::array::from_fn(|i| {
-            FromNode::from_node(__extract::<T>(node, i))
+            FromNode::from_node(__extract::<T>(node.get(), i).into())
         }))
     }
 }
@@ -67,9 +67,9 @@ impl<T: VectorAlign<N>, const N: usize> FromNode for VectorVarData<T, N> {
 #[derive(Copy, Clone)]
 pub struct VectorAtomicRefData<T: VectorAlign<N>, const N: usize>([AtomicRef<T>; N]);
 impl<T: VectorAlign<N>, const N: usize> FromNode for VectorAtomicRefData<T, N> {
-    fn from_node(node: NodeRef) -> Self {
+    fn from_node(node: SafeNodeRef) -> Self {
         Self(std::array::from_fn(|i| {
-            FromNode::from_node(__extract::<T>(node, i))
+            FromNode::from_node(__extract::<T>(node.get(), i).into())
         }))
     }
 }
@@ -78,7 +78,7 @@ impl<T: VectorAlign<N>, const N: usize> FromNode for VectorAtomicRefData<T, N> {
 #[derive(Debug, Copy, Clone)]
 pub struct DoubledProxyData<X: FromNode + Copy>(X, X);
 impl<X: FromNode + Copy> FromNode for DoubledProxyData<X> {
-    fn from_node(node: NodeRef) -> Self {
+    fn from_node(node: SafeNodeRef) -> Self {
         Self(X::from_node(node), X::from_node(node))
     }
 }
@@ -161,7 +161,7 @@ macro_rules! vector_proxies {
                 let mut comp = 0;
                 $(
                     {
-                        let el = Expr::<T>::from_node(__extract::<T>(v.node(), comp));
+                        let el = Expr::<T>::from_node(__extract::<T>(v.node().get(), comp).into());
                         self.$real_c.write(i, el);
                         comp += 1;
                     }
@@ -191,7 +191,7 @@ macro_rules! vector_proxies {
         impl<T: VectorAlign<$N>> VectorExprProxy for $ExprName<T> {
             const N: usize = $N;
             type T = T;
-            fn node(&self) -> NodeRef {
+            fn node(&self) -> SafeNodeRef {
                 self.self_.node()
             }
         }

--- a/luisa_compute/src/lang/types/vector/impls.rs
+++ b/luisa_compute/src/lang/types/vector/impls.rs
@@ -39,7 +39,8 @@ impl<T: VectorAlign<N>, const N: usize> Vector<T, N> {
         }
     }
     pub fn from_elems_expr(elements: [Expr<T>; N]) -> Expr<Self> {
-        Expr::<Self>::from_node(__compose::<Vector<T, N>>(&elements.map(|x| x.node())))
+        let elements = elements.map(|x| x.node().get());
+        Expr::<Self>::from_node(__compose::<Vector<T, N>>(&elements).into())
     }
 }
 

--- a/luisa_compute/src/lib.rs
+++ b/luisa_compute/src/lib.rs
@@ -66,7 +66,7 @@ mod internal_prelude {
     pub(crate) use crate::lang::{
         check_index_lt_usize, ir, CallFuncTrait, FnRecorder, SafeNodeRef, __compose, __extract,
         __insert, __module_pools, need_runtime_check, FromNode, NodeLike, NodeRef, ToNode,
-        __current_scope, __pop_scope, RECORDER,
+        __current_scope, __pop_scope, with_recorder, RECORDER,
     };
     pub(crate) use crate::prelude::*;
     pub(crate) use crate::runtime::{

--- a/luisa_compute/src/lib.rs
+++ b/luisa_compute/src/lib.rs
@@ -64,9 +64,9 @@ mod internal_prelude {
     pub(crate) use crate::lang::types::{vector::*, SoaBufferProxy};
     #[allow(unused_imports)]
     pub(crate) use crate::lang::{
-        check_index_lt_usize, ir, CallFuncTrait, Recorder, __compose, __extract, __insert,
-        __module_pools, need_runtime_check, FromNode, NodeLike, NodeRef, ToNode, __current_scope,
-        __pop_scope, RECORDER,
+        check_index_lt_usize, ir, CallFuncTrait, FnRecorder, SafeNodeRef, __compose, __extract,
+        __insert, __module_pools, need_runtime_check, FromNode, NodeLike, NodeRef, ToNode,
+        __current_scope, __pop_scope, RECORDER,
     };
     pub(crate) use crate::prelude::*;
     pub(crate) use crate::runtime::{

--- a/luisa_compute/src/lib.rs
+++ b/luisa_compute/src/lib.rs
@@ -36,7 +36,7 @@ pub mod prelude {
     pub use crate::lang::types::vector::swizzle::*;
     pub use crate::lang::types::vector::VectorExprProxy;
     pub use crate::lang::types::{AsExpr, Expr, SoaValue, Value, Var};
-    pub use crate::lang::Aggregate;
+    pub use crate::lang::{outline, Aggregate};
     pub use crate::resource::{IoTexel, StorageTexel, *};
     pub use crate::runtime::api::StreamTag;
     pub use crate::runtime::{

--- a/luisa_compute/src/resource.rs
+++ b/luisa_compute/src/resource.rs
@@ -2235,7 +2235,7 @@ impl<T: IoTexel> Tex2dVar<T> {
             r.capture_or_get(binding, &view.tex.handle, || {
                 Node::new(CArc::new(Instruction::Texture2D), T::RwType::type_())
             })
-        });
+        }).into();
         Self {
             node,
             handle: Some(view.tex.handle.clone()),
@@ -2244,31 +2244,27 @@ impl<T: IoTexel> Tex2dVar<T> {
         }
     }
     pub fn read(&self, uv: impl AsExpr<Value = Uint2>) -> Expr<T> {
-        let uv = uv.as_expr();
-        T::convert_from_read(Expr::<T::RwType>::from_node(__current_scope(|b| {
-            b.call(
-                Func::Texture2dRead,
-                &[self.node, uv.node()],
-                T::RwType::type_(),
-            )
-        })))
+        let uv = uv.as_expr().node().get();
+        let self_node = self.node.get();
+        T::convert_from_read(Expr::<T::RwType>::from_node(
+            __current_scope(|b| b.call(Func::Texture2dRead, &[self_node, uv], T::RwType::type_()))
+                .into(),
+        ))
     }
     pub fn write(&self, uv: impl AsExpr<Value = Uint2>, v: impl AsExpr<Value = T>) {
-        let uv = uv.as_expr();
+        let uv = uv.as_expr().node().get();
         let v = v.as_expr();
-        let v = T::convert_to_write(v);
+        let v = T::convert_to_write(v).node().get();
+        let self_node = self.node.get();
         __current_scope(|b| {
-            b.call(
-                Func::Texture2dWrite,
-                &[self.node, uv.node(), v.node()],
-                Type::void(),
-            );
+            b.call(Func::Texture2dWrite, &[self_node, uv, v], Type::void());
         })
     }
     pub fn size(&self) -> Expr<Uint2> {
-        Expr::<Uint2>::from_node(__current_scope(|b| {
-            b.call(Func::Texture2dSize, &[self.node], Uint2::type_())
-        }))
+        let self_node = self.node.get();
+        Expr::<Uint2>::from_node(
+            __current_scope(|b| b.call(Func::Texture2dSize, &[self_node], Uint2::type_())).into(),
+        )
     }
 }
 
@@ -2289,7 +2285,7 @@ impl<T: IoTexel> Tex3dVar<T> {
             r.capture_or_get(binding, &view.tex.handle, || {
                 Node::new(CArc::new(Instruction::Texture3D), T::RwType::type_())
             })
-        });
+        }).into();
         Self {
             node,
             handle: Some(view.tex.handle.clone()),
@@ -2298,31 +2294,27 @@ impl<T: IoTexel> Tex3dVar<T> {
         }
     }
     pub fn read(&self, uv: impl AsExpr<Value = Uint3>) -> Expr<T> {
-        let uv = uv.as_expr();
-        T::convert_from_read(Expr::<T::RwType>::from_node(__current_scope(|b| {
-            b.call(
-                Func::Texture3dRead,
-                &[self.node, uv.node()],
-                T::RwType::type_(),
-            )
-        })))
+        let uv = uv.as_expr().node().get();
+        let self_node = self.node.get();
+        T::convert_from_read(Expr::<T::RwType>::from_node(
+            __current_scope(|b| b.call(Func::Texture3dRead, &[self_node, uv], T::RwType::type_()))
+                .into(),
+        ))
     }
     pub fn write(&self, uv: impl AsExpr<Value = Uint3>, v: impl AsExpr<Value = T>) {
-        let uv = uv.as_expr();
+        let uv = uv.as_expr().node().get();
         let v = v.as_expr();
-        let v = T::convert_to_write(v);
+        let v = T::convert_to_write(v).node().get();
+        let self_node = self.node.get();
         __current_scope(|b| {
-            b.call(
-                Func::Texture3dWrite,
-                &[self.node, uv.node(), v.node()],
-                Type::void(),
-            );
+            b.call(Func::Texture3dWrite, &[self_node, uv, v], Type::void());
         })
     }
     pub fn size(&self) -> Expr<Uint3> {
-        Expr::<Uint3>::from_node(__current_scope(|b| {
-            b.call(Func::Texture3dSize, &[self.node], Uint3::type_())
-        }))
+        let self_node = self.node.get();
+        Expr::<Uint3>::from_node(
+            __current_scope(|b| b.call(Func::Texture3dSize, &[self_node], Uint3::type_())).into(),
+        )
     }
 }
 #[derive(Clone)]

--- a/luisa_compute/src/resource.rs
+++ b/luisa_compute/src/resource.rs
@@ -245,13 +245,15 @@ pub type ByteBufferVar = BufferVar<u8>;
 impl BufferVar<u8> {
     pub unsafe fn read_as<T: Value>(&self, index_bytes: impl IntoIndex) -> Expr<T> {
         let i = index_bytes.to_u64();
+        let self_node = self.node;
+        let i = i.node().get();
         Expr::<T>::from_node(__current_scope(|b| {
             b.call(
                 Func::ByteBufferRead,
                 &[self.node, i.node],
                 <T as TypeOf>::type_(),
             )
-        }))
+        }).into())
     }
     pub fn len_bytes_expr(&self) -> Expr<u64> {
         Expr::<u64>::from_node(__current_scope(|b| {
@@ -1412,10 +1414,10 @@ pub struct BufferVar<T: Value> {
     pub(crate) marker: PhantomData<T>,
     #[allow(dead_code)]
     pub(crate) handle: Option<Arc<BufferHandle>>,
-    pub(crate) node: NodeRef,
+    pub(crate) node: SafeNodeRef,
 }
 impl<T: Value> ToNode for BufferVar<T> {
-    fn node(&self) -> NodeRef {
+    fn node(&self) -> SafeNodeRef {
         self.node
     }
 }
@@ -1424,18 +1426,18 @@ impl<T: Value> Drop for BufferVar<T> {
 }
 #[derive(Clone)]
 pub struct BindlessArrayVar {
-    pub(crate) node: NodeRef,
+    pub(crate) node: SafeNodeRef,
     #[allow(dead_code)]
     pub(crate) handle: Option<Arc<BindlessArrayHandle>>,
 }
 #[derive(Clone)]
 pub struct BindlessBufferVar<T> {
-    array: NodeRef,
+    array: SafeNodeRef,
     buffer_index: Expr<u32>,
     _marker: PhantomData<T>,
 }
 impl<T: Value> ToNode for BindlessBufferVar<T> {
-    fn node(&self) -> NodeRef {
+    fn node(&self) -> SafeNodeRef {
         self.array
     }
 }
@@ -1501,11 +1503,11 @@ impl<T: Value> BindlessBufferVar<T> {
 }
 #[derive(Clone)]
 pub struct BindlessByteBufferVar {
-    array: NodeRef,
+    array: SafeNodeRef,
     buffer_index: Expr<u32>,
 }
 impl ToNode for BindlessByteBufferVar {
-    fn node(&self) -> NodeRef {
+    fn node(&self) -> SafeNodeRef {
         self.array
     }
 }
@@ -1533,7 +1535,7 @@ impl BindlessByteBufferVar {
 }
 #[derive(Clone)]
 pub struct BindlessTex2dVar {
-    array: NodeRef,
+    array: SafeNodeRef,
     tex2d_index: Expr<u32>,
 }
 
@@ -1620,7 +1622,7 @@ impl BindlessTex2dVar {
 }
 #[derive(Clone)]
 pub struct BindlessTex3dVar {
-    array: NodeRef,
+    array: SafeNodeRef,
     tex3d_index: Expr<u32>,
 }
 
@@ -1790,7 +1792,7 @@ impl BindlessArrayVar {
     }
 }
 impl<T: Value> ToNode for Buffer<T> {
-    fn node(&self) -> NodeRef {
+    fn node(&self) -> SafeNodeRef {
         self.var().node()
     }
 }
@@ -2068,7 +2070,7 @@ impl_atomic_bit!(i32);
 impl_atomic_bit!(i64);
 #[derive(Clone)]
 pub struct Tex2dVar<T: IoTexel> {
-    pub(crate) node: NodeRef,
+    pub(crate) node: SafeNodeRef,
     #[allow(dead_code)]
     pub(crate) handle: Option<Arc<TextureHandle>>,
     pub(crate) marker: PhantomData<T>,
@@ -2189,7 +2191,7 @@ impl<T: IoTexel> Tex3dVar<T> {
 }
 #[derive(Clone)]
 pub struct Tex3dVar<T: IoTexel> {
-    pub(crate) node: NodeRef,
+    pub(crate) node: SafeNodeRef,
     #[allow(dead_code)]
     pub(crate) handle: Option<Arc<TextureHandle>>,
     pub(crate) marker: PhantomData<T>,

--- a/luisa_compute/src/resource.rs
+++ b/luisa_compute/src/resource.rs
@@ -245,35 +245,37 @@ pub type ByteBufferVar = BufferVar<u8>;
 impl BufferVar<u8> {
     pub unsafe fn read_as<T: Value>(&self, index_bytes: impl IntoIndex) -> Expr<T> {
         let i = index_bytes.to_u64();
-        let self_node = self.node;
+        let self_node = self.node.get();
         let i = i.node().get();
-        Expr::<T>::from_node(__current_scope(|b| {
-            b.call(
-                Func::ByteBufferRead,
-                &[self.node, i.node],
-                <T as TypeOf>::type_(),
-            )
-        }).into())
+        Expr::<T>::from_node(
+            __current_scope(|b| {
+                b.call(
+                    Func::ByteBufferRead,
+                    &[self_node, i],
+                    <T as TypeOf>::type_(),
+                )
+            })
+            .into(),
+        )
     }
     pub fn len_bytes_expr(&self) -> Expr<u64> {
-        Expr::<u64>::from_node(__current_scope(|b| {
-            b.call(Func::ByteBufferSize, &[self.node], <u64 as TypeOf>::type_())
-        }))
+        let self_node = self.node.get();
+        Expr::<u64>::from_node(
+            __current_scope(|b| {
+                b.call(Func::ByteBufferSize, &[self_node], <u64 as TypeOf>::type_())
+            })
+            .into(),
+        )
     }
     pub unsafe fn write_as<T: Value>(
         &self,
         index_bytes: impl IntoIndex,
-        value: impl Into<Expr<T>>,
+        value: impl AsExpr<Value = T>,
     ) {
-        let i = index_bytes.to_u64();
-        let value: Expr<T> = value.into();
-        __current_scope(|b| {
-            b.call(
-                Func::ByteBufferWrite,
-                &[self.node, i.node, value.node()],
-                Type::void(),
-            )
-        });
+        let i = index_bytes.to_u64().node().get();
+        let value = value.as_expr().node().get();
+        let self_node = self.node.get();
+        __current_scope(|b| b.call(Func::ByteBufferWrite, &[self_node, i, value], Type::void()));
     }
 }
 pub struct Buffer<T: Value> {
@@ -849,7 +851,8 @@ impl BindlessArray {
     pub fn update(&self) {
         submit_default_stream_and_sync(&self.device, [self.update_async()]);
     }
-    pub fn update_async<'a>(&'a self) -> Command<'a, 'a> { // What lifetime should this be?
+    pub fn update_async<'a>(&'a self) -> Command<'a, 'a> {
+        // What lifetime should this be?
         self.lock();
         let mut rt = ResourceTracker::new();
         let modifications = Arc::new(std::mem::replace(
@@ -1165,7 +1168,10 @@ impl<T: IoTexel> Tex3d<T> {
 macro_rules! impl_tex_view {
     ($name:ident) => {
         impl<'a, T: IoTexel> $name<'a, T> {
-            pub fn copy_to_async<U: StorageTexel<T>>(&'a self, data: &'a mut [U]) -> Command<'a, 'a> {
+            pub fn copy_to_async<U: StorageTexel<T>>(
+                &'a self,
+                data: &'a mut [U],
+            ) -> Command<'a, 'a> {
                 assert_eq!(data.len(), self.texel_count() as usize);
                 assert_eq!(self.tex.handle.storage, U::pixel_storage());
                 let mut rt = ResourceTracker::new();
@@ -1196,7 +1202,10 @@ macro_rules! impl_tex_view {
                 self.copy_to(&mut data);
                 data
             }
-            pub fn copy_from_async<'b, U: StorageTexel<T>>(&'a self, data: &'b [U]) -> Command<'b, 'static> {
+            pub fn copy_from_async<'b, U: StorageTexel<T>>(
+                &'a self,
+                data: &'b [U],
+            ) -> Command<'b, 'static> {
                 assert_eq!(data.len(), self.texel_count() as usize);
                 assert_eq!(self.tex.handle.storage, U::pixel_storage());
                 let mut rt = ResourceTracker::new();
@@ -1449,14 +1458,19 @@ impl<T: Value> IndexRead for BindlessBufferVar<T> {
         if need_runtime_check() {
             lc_assert!(i.lt(self.len_expr()));
         }
-
-        Expr::<T>::from_node(__current_scope(|b| {
-            b.call(
-                Func::BindlessBufferRead,
-                &[self.array, self.buffer_index.node(), ToNode::node(&i)],
-                T::type_(),
-            )
-        }))
+        let array = self.array.get();
+        let buffer_index = self.buffer_index.node().get();
+        let i = i.node().get();
+        Expr::<T>::from_node(
+            __current_scope(|b| {
+                b.call(
+                    Func::BindlessBufferRead,
+                    &[array, buffer_index, i],
+                    T::type_(),
+                )
+            })
+            .into(),
+        )
     }
 }
 impl<T: Value> IndexWrite for BindlessBufferVar<T> {
@@ -1465,16 +1479,14 @@ impl<T: Value> IndexWrite for BindlessBufferVar<T> {
         if need_runtime_check() {
             lc_assert!(i.lt(self.len_expr()));
         }
-        let value = value.as_expr();
+        let array = self.array.get();
+        let buffer_index = self.buffer_index.node().get();
+        let i = i.node().get();
+        let value = value.as_expr().node().get();
         __current_scope(|b| {
             b.call(
                 Func::BindlessBufferWrite,
-                &[
-                    self.array,
-                    self.buffer_index.node(),
-                    ToNode::node(&i),
-                    value.node(),
-                ],
+                &[array, buffer_index, i, value],
                 Type::void(),
             )
         });
@@ -1482,23 +1494,33 @@ impl<T: Value> IndexWrite for BindlessBufferVar<T> {
 }
 impl<T: Value> BindlessBufferVar<T> {
     pub fn len_expr(&self) -> Expr<u64> {
-        let stride = (T::type_().size() as u64).expr();
-        Expr::<u64>::from_node(__current_scope(|b| {
-            b.call(
-                Func::BindlessBufferSize,
-                &[self.array, self.buffer_index.node(), stride.node()],
-                u32::type_(),
-            )
-        }))
+        let stride = (T::type_().size() as u64).expr().node().get();
+        let array = self.array.get();
+        let buffer_index = self.buffer_index.node().get();
+        Expr::<u64>::from_node(
+            __current_scope(|b| {
+                b.call(
+                    Func::BindlessBufferSize,
+                    &[array, buffer_index, stride],
+                    u32::type_(),
+                )
+            })
+            .into(),
+        )
     }
     pub fn __type(&self) -> Expr<u64> {
-        Expr::<u64>::from_node(__current_scope(|b| {
-            b.call(
-                Func::BindlessBufferType,
-                &[self.array, self.buffer_index.node()],
-                u64::type_(),
-            )
-        }))
+        let array = self.array.get();
+        let buffer_index = self.buffer_index.node().get();
+        Expr::<u64>::from_node(
+            __current_scope(|b| {
+                b.call(
+                    Func::BindlessBufferType,
+                    &[array, buffer_index],
+                    u64::type_(),
+                )
+            })
+            .into(),
+        )
     }
 }
 #[derive(Clone)]
@@ -1513,24 +1535,34 @@ impl ToNode for BindlessByteBufferVar {
 }
 impl BindlessByteBufferVar {
     pub unsafe fn read_as<T: Value>(&self, index_bytes: impl IntoIndex) -> Expr<T> {
-        let i = index_bytes.to_u64();
-        Expr::<T>::from_node(__current_scope(|b| {
-            b.call(
-                Func::BindlessByteBufferRead,
-                &[self.array, self.buffer_index.node(), i.node],
-                <T as TypeOf>::type_(),
-            )
-        }))
+        let i = index_bytes.to_u64().node().get();
+        let array = self.array.get();
+        let buffer_index = self.buffer_index.node().get();
+        Expr::<T>::from_node(
+            __current_scope(|b| {
+                b.call(
+                    Func::BindlessByteBufferRead,
+                    &[array, buffer_index, i],
+                    <T as TypeOf>::type_(),
+                )
+            })
+            .into(),
+        )
     }
     pub fn len(&self) -> Expr<u64> {
-        let s = (1u64).expr();
-        Expr::<u64>::from_node(__current_scope(|b| {
-            b.call(
-                Func::BindlessBufferSize,
-                &[self.array, self.buffer_index.node(), s.node()],
-                <u64 as TypeOf>::type_(),
-            )
-        }))
+        let s = (1u64).expr().node().get();
+        let array = self.array.get();
+        let buffer_index = self.buffer_index.node().get();
+        Expr::<u64>::from_node(
+            __current_scope(|b| {
+                b.call(
+                    Func::BindlessBufferSize,
+                    &[array, buffer_index, s],
+                    <u64 as TypeOf>::type_(),
+                )
+            })
+            .into(),
+        )
     }
 }
 #[derive(Clone)]
@@ -1540,84 +1572,126 @@ pub struct BindlessTex2dVar {
 }
 
 impl BindlessTex2dVar {
-    pub fn sample(&self, uv: Expr<Float2>) -> Expr<Float4> {
-        Expr::<Float4>::from_node(__current_scope(|b| {
-            b.call(
-                Func::BindlessTexture2dSample,
-                &[self.array, self.tex2d_index.node(), uv.node()],
-                Float4::type_(),
-            )
-        }))
+    pub fn sample(&self, uv: impl AsExpr<Value = Float2>) -> Expr<Float4> {
+        let array = self.array.get();
+        let tex2d_index = self.tex2d_index.node().get();
+        let uv = uv.as_expr().node().get();
+        Expr::<Float4>::from_node(
+            __current_scope(|b| {
+                b.call(
+                    Func::BindlessTexture2dSample,
+                    &[array, tex2d_index, uv],
+                    Float4::type_(),
+                )
+            })
+            .into(),
+        )
     }
-    pub fn sample_level(&self, uv: Expr<Float2>, level: Expr<f32>) -> Expr<Float4> {
-        Expr::<Float4>::from_node(__current_scope(|b| {
-            b.call(
-                Func::BindlessTexture2dSampleLevel,
-                &[self.array, self.tex2d_index.node(), uv.node(), level.node()],
-                Float4::type_(),
-            )
-        }))
+    pub fn sample_level(
+        &self,
+        uv: impl AsExpr<Value = Float2>,
+        level: impl AsExpr<Value = u32>,
+    ) -> Expr<Float4> {
+        let array = self.array.get();
+        let tex2d_index = self.tex2d_index.node().get();
+        let uv = uv.as_expr().node().get();
+        let level = level.as_expr().node().get();
+        Expr::<Float4>::from_node(
+            __current_scope(|b| {
+                b.call(
+                    Func::BindlessTexture2dSampleLevel,
+                    &[array, tex2d_index, uv, level],
+                    Float4::type_(),
+                )
+            })
+            .into(),
+        )
     }
     pub fn sample_grad(
         &self,
-        uv: Expr<Float2>,
-        ddx: Expr<Float2>,
-        ddy: Expr<Float2>,
+        uv: impl AsExpr<Value = Float2>,
+        ddx: impl AsExpr<Value = Float2>,
+        ddy: impl AsExpr<Value = Float2>,
     ) -> Expr<Float4> {
-        Expr::<Float4>::from_node(__current_scope(|b| {
-            b.call(
-                Func::BindlessTexture2dSampleLevel,
-                &[
-                    self.array,
-                    self.tex2d_index.node(),
-                    uv.node(),
-                    ddx.node(),
-                    ddy.node(),
-                ],
-                Float4::type_(),
-            )
-        }))
+        let array = self.array.get();
+        let tex2d_index = self.tex2d_index.node().get();
+        let uv = uv.as_expr().node().get();
+        let ddx = ddx.as_expr().node().get();
+        let ddy = ddy.as_expr().node().get();
+        Expr::<Float4>::from_node(
+            __current_scope(|b| {
+                b.call(
+                    Func::BindlessTexture2dSampleLevel,
+                    &[array, tex2d_index, uv, ddx, ddy],
+                    Float4::type_(),
+                )
+            })
+            .into(),
+        )
     }
-    pub fn read(&self, coord: Expr<Uint2>) -> Expr<Float4> {
-        Expr::<Float4>::from_node(__current_scope(|b| {
-            b.call(
-                Func::BindlessTexture2dRead,
-                &[self.array, self.tex2d_index.node(), coord.node()],
-                Float4::type_(),
-            )
-        }))
+    pub fn read(&self, coord: impl AsExpr<Value = Uint2>) -> Expr<Float4> {
+        let array = self.array.get();
+        let tex2d_index = self.tex2d_index.node().get();
+        let coord = coord.as_expr().node().get();
+        Expr::<Float4>::from_node(
+            __current_scope(|b| {
+                b.call(
+                    Func::BindlessTexture2dRead,
+                    &[array, tex2d_index, coord],
+                    Float4::type_(),
+                )
+            })
+            .into(),
+        )
     }
-    pub fn read_level(&self, coord: Expr<Uint2>, level: Expr<u32>) -> Expr<Float4> {
-        Expr::<Float4>::from_node(__current_scope(|b| {
-            b.call(
-                Func::BindlessTexture2dReadLevel,
-                &[
-                    self.array,
-                    self.tex2d_index.node(),
-                    coord.node(),
-                    level.node(),
-                ],
-                Float4::type_(),
-            )
-        }))
+    pub fn read_level(
+        &self,
+        coord: impl AsExpr<Value = Uint2>,
+        level: impl AsExpr<Value = u32>,
+    ) -> Expr<Float4> {
+        let array = self.array.get();
+        let tex2d_index = self.tex2d_index.node().get();
+        let coord = coord.as_expr().node().get();
+        let level = level.as_expr().node().get();
+        Expr::<Float4>::from_node(
+            __current_scope(|b| {
+                b.call(
+                    Func::BindlessTexture2dReadLevel,
+                    &[array, tex2d_index, coord, level],
+                    Float4::type_(),
+                )
+            })
+            .into(),
+        )
     }
     pub fn size(&self) -> Expr<Uint2> {
-        Expr::<Uint2>::from_node(__current_scope(|b| {
-            b.call(
-                Func::BindlessTexture2dSize,
-                &[self.array, self.tex2d_index.node()],
-                Uint2::type_(),
-            )
-        }))
+        Expr::<Uint2>::from_node(
+            __current_scope(|b| {
+                let array = self.array.get();
+                let tex2d_index = self.tex2d_index.node().get();
+                b.call(
+                    Func::BindlessTexture2dSize,
+                    &[array, tex2d_index],
+                    Uint2::type_(),
+                )
+            })
+            .into(),
+        )
     }
-    pub fn size_level(&self, level: Expr<u32>) -> Expr<Uint2> {
-        Expr::<Uint2>::from_node(__current_scope(|b| {
-            b.call(
-                Func::BindlessTexture2dSizeLevel,
-                &[self.array, self.tex2d_index.node(), level.node()],
-                Uint2::type_(),
-            )
-        }))
+    pub fn size_level(&self, level: impl AsExpr<Value = u32>) -> Expr<Uint2> {
+        let array = self.array.get();
+        let tex2d_index = self.tex2d_index.node().get();
+        let level = level.as_expr().node().get();
+        Expr::<Uint2>::from_node(
+            __current_scope(|b| {
+                b.call(
+                    Func::BindlessTexture2dSizeLevel,
+                    &[array, tex2d_index, level],
+                    Uint2::type_(),
+                )
+            })
+            .into(),
+        )
     }
 }
 #[derive(Clone)]
@@ -1627,84 +1701,126 @@ pub struct BindlessTex3dVar {
 }
 
 impl BindlessTex3dVar {
-    pub fn sample(&self, uv: Expr<Float3>) -> Expr<Float4> {
-        Expr::<Float4>::from_node(__current_scope(|b| {
-            b.call(
-                Func::BindlessTexture3dSample,
-                &[self.array, self.tex3d_index.node(), uv.node()],
-                Float4::type_(),
-            )
-        }))
+    pub fn sample(&self, uv: impl AsExpr<Value = Float3>) -> Expr<Float4> {
+        let array = self.array.get();
+        let tex3d_index = self.tex3d_index.node().get();
+        let uv = uv.as_expr().node().get();
+        Expr::<Float4>::from_node(
+            __current_scope(|b| {
+                b.call(
+                    Func::BindlessTexture3dSample,
+                    &[array, tex3d_index, uv],
+                    Float4::type_(),
+                )
+            })
+            .into(),
+        )
     }
-    pub fn sample_level(&self, uv: Expr<Float3>, level: Expr<f32>) -> Expr<Float4> {
-        Expr::<Float4>::from_node(__current_scope(|b| {
-            b.call(
-                Func::BindlessTexture3dSampleLevel,
-                &[self.array, self.tex3d_index.node(), uv.node(), level.node()],
-                Float4::type_(),
-            )
-        }))
+    pub fn sample_level(
+        &self,
+        uv: impl AsExpr<Value = Float3>,
+        level: impl AsExpr<Value = f32>,
+    ) -> Expr<Float4> {
+        let array = self.array.get();
+        let tex3d_index = self.tex3d_index.node().get();
+        let uv = uv.as_expr().node().get();
+        let level = level.as_expr().node().get();
+        Expr::<Float4>::from_node(
+            __current_scope(|b| {
+                b.call(
+                    Func::BindlessTexture3dSampleLevel,
+                    &[array, tex3d_index, uv, level],
+                    Float4::type_(),
+                )
+            })
+            .into(),
+        )
     }
     pub fn sample_grad(
         &self,
-        uv: Expr<Float3>,
-        ddx: Expr<Float3>,
-        ddy: Expr<Float3>,
+        uv: impl AsExpr<Value = Float3>,
+        ddx: impl AsExpr<Value = Float3>,
+        ddy: impl AsExpr<Value = Float3>,
     ) -> Expr<Float4> {
-        Expr::<Float4>::from_node(__current_scope(|b| {
-            b.call(
-                Func::BindlessTexture3dSampleLevel,
-                &[
-                    self.array,
-                    self.tex3d_index.node(),
-                    uv.node(),
-                    ddx.node(),
-                    ddy.node(),
-                ],
-                Float4::type_(),
-            )
-        }))
+        let array = self.array.get();
+        let tex3d_index = self.tex3d_index.node().get();
+        let uv = uv.as_expr().node().get();
+        let ddx = ddx.as_expr().node().get();
+        let ddy = ddy.as_expr().node().get();
+        Expr::<Float4>::from_node(
+            __current_scope(|b| {
+                b.call(
+                    Func::BindlessTexture3dSampleLevel,
+                    &[array, tex3d_index, uv, ddx, ddy],
+                    Float4::type_(),
+                )
+            })
+            .into(),
+        )
     }
-    pub fn read(&self, coord: Expr<Uint3>) -> Expr<Float4> {
-        Expr::<Float4>::from_node(__current_scope(|b| {
-            b.call(
-                Func::BindlessTexture3dRead,
-                &[self.array, self.tex3d_index.node(), coord.node()],
-                Float4::type_(),
-            )
-        }))
+    pub fn read(&self, coord: impl AsExpr<Value = Uint3>) -> Expr<Float4> {
+        let array = self.array.get();
+        let tex3d_index = self.tex3d_index.node().get();
+        let coord = coord.as_expr().node().get();
+        Expr::<Float4>::from_node(
+            __current_scope(|b| {
+                b.call(
+                    Func::BindlessTexture3dRead,
+                    &[array, tex3d_index, coord],
+                    Float4::type_(),
+                )
+            })
+            .into(),
+        )
     }
-    pub fn read_level(&self, coord: Expr<Uint3>, level: Expr<u32>) -> Expr<Float4> {
-        Expr::<Float4>::from_node(__current_scope(|b| {
-            b.call(
-                Func::BindlessTexture3dReadLevel,
-                &[
-                    self.array,
-                    self.tex3d_index.node(),
-                    coord.node(),
-                    level.node(),
-                ],
-                Float4::type_(),
-            )
-        }))
+    pub fn read_level(
+        &self,
+        coord: impl AsExpr<Value = Uint3>,
+        level: impl AsExpr<Value = f32>,
+    ) -> Expr<Float4> {
+        let array = self.array.get();
+        let tex3d_index = self.tex3d_index.node().get();
+        let coord = coord.as_expr().node().get();
+        let level = level.as_expr().node().get();
+        Expr::<Float4>::from_node(
+            __current_scope(|b| {
+                b.call(
+                    Func::BindlessTexture3dReadLevel,
+                    &[array, tex3d_index, coord, level],
+                    Float4::type_(),
+                )
+            })
+            .into(),
+        )
     }
     pub fn size(&self) -> Expr<Uint3> {
-        Expr::<Uint3>::from_node(__current_scope(|b| {
-            b.call(
-                Func::BindlessTexture3dSize,
-                &[self.array, self.tex3d_index.node()],
-                Uint3::type_(),
-            )
-        }))
+        let array = self.array.get();
+        let tex3d_index = self.tex3d_index.node().get();
+        Expr::<Uint3>::from_node(
+            __current_scope(|b| {
+                b.call(
+                    Func::BindlessTexture3dSize,
+                    &[array, tex3d_index],
+                    Uint3::type_(),
+                )
+            })
+            .into(),
+        )
     }
-    pub fn size_level(&self, level: Expr<u32>) -> Expr<Uint3> {
-        Expr::<Uint3>::from_node(__current_scope(|b| {
-            b.call(
-                Func::BindlessTexture3dSizeLevel,
-                &[self.array, self.tex3d_index.node(), level.node()],
-                Uint3::type_(),
-            )
-        }))
+    pub fn size_level(&self, level: impl AsExpr<Value = f32>) -> Expr<Uint3> {
+        let array = self.array.get();
+        let tex3d_index = self.tex3d_index.node().get();
+        let level = level.as_expr().node().get();
+        Expr::<Uint3>::from_node(
+            __current_scope(|b| {
+                b.call(
+                    Func::BindlessTexture3dSizeLevel,
+                    &[array, tex3d_index, level],
+                    Uint3::type_(),
+                )
+            })
+            .into(),
+        )
     }
 }
 
@@ -1767,12 +1883,7 @@ impl BindlessArrayVar {
     }
 
     pub fn new(array: &BindlessArray) -> Self {
-        let node = RECORDER.with(|r| {
-            let mut r = r.borrow_mut();
-            assert!(
-                r.lock,
-                "BindlessArrayVar must be created from within a kernel"
-            );
+        let node = with_recorder(|r| {
             let handle: u64 = array.handle().0;
             let binding = Binding::BindlessArray(BindlessArrayBinding { handle });
             if let Some((a, b)) = r.check_on_same_device(&array.device) {
@@ -1784,7 +1895,8 @@ impl BindlessArrayVar {
             r.capture_or_get(binding, &array.handle, || {
                 Node::new(CArc::new(Instruction::Bindless), Type::void())
             })
-        });
+        })
+        .into();
         Self {
             node,
             handle: Some(array.handle.clone()),
@@ -1814,32 +1926,28 @@ impl<T: Value> IndexRead for BufferVar<T> {
         if need_runtime_check() {
             lc_assert!(i.lt(self.len_expr()));
         }
-        Expr::<T>::from_node(__current_scope(|b| {
-            b.call(Func::BufferRead, &[self.node, ToNode::node(&i)], T::type_())
-        }))
+        let self_node = self.node.get();
+        let i = i.node.get();
+        Expr::<T>::from_node(
+            __current_scope(|b| b.call(Func::BufferRead, &[self_node, i], T::type_())).into(),
+        )
     }
 }
 impl<T: Value> IndexWrite for BufferVar<T> {
     fn write<I: IntoIndex, V: AsExpr<Value = T>>(&self, i: I, v: V) {
         let i = i.to_u64();
-        let v = v.as_expr();
+        let v = v.as_expr().node().get();
         if need_runtime_check() {
             lc_assert!(i.lt(self.len_expr()));
         }
-        __current_scope(|b| {
-            b.call(
-                Func::BufferWrite,
-                &[self.node, ToNode::node(&i), v.node()],
-                Type::void(),
-            )
-        });
+        let i = i.node().get();
+        let self_node = self.node.get();
+        __current_scope(|b| b.call(Func::BufferWrite, &[self_node, i, v], Type::void()));
     }
 }
 impl<T: Value> BufferVar<T> {
     pub fn new(buffer: &BufferView<'_, T>) -> Self {
-        let node = RECORDER.with(|r| {
-            let mut r = r.borrow_mut();
-            assert!(r.lock, "BufferVar must be created from within a kernel");
+        let node = with_recorder(|r| {
             let binding = Binding::Buffer(BufferBinding {
                 handle: buffer.handle().0,
                 size: buffer.len * std::mem::size_of::<T>(),
@@ -1854,7 +1962,8 @@ impl<T: Value> BufferVar<T> {
             r.capture_or_get(binding, &buffer.buffer.handle, || {
                 Node::new(CArc::new(Instruction::Buffer), T::type_())
             })
-        });
+        })
+        .into();
         Self {
             node,
             marker: PhantomData,
@@ -1863,18 +1972,26 @@ impl<T: Value> BufferVar<T> {
     }
     pub fn atomic_ref(&self, i: impl IntoIndex) -> AtomicRef<T> {
         let i = i.to_u64();
-        AtomicRef::<T>::from_node(__current_scope(|b| {
-            b.call_no_append(Func::AtomicRef, &[self.node, i.node()], T::type_())
-        }))
+        if need_runtime_check() {
+            lc_assert!(i.lt(self.len_expr()));
+        }
+        let i = i.node().get();
+        let self_node = self.node.get();
+        AtomicRef::<T>::from_node(
+            __current_scope(|b| b.call_no_append(Func::AtomicRef, &[self_node, i], T::type_()))
+                .into(),
+        )
     }
     pub fn len_expr(&self) -> Expr<u64> {
+        let self_node = self.node.get();
         FromNode::from_node(
-            __current_scope(|b| b.call(Func::BufferSize, &[self.node], u64::type_())).into(),
+            __current_scope(|b| b.call(Func::BufferSize, &[self_node], u64::type_())).into(),
         )
     }
     pub fn len_expr_u32(&self) -> Expr<u32> {
+        let self_node = self.node.get();
         FromNode::from_node(
-            __current_scope(|b| b.call(Func::BufferSize, &[self.node], u32::type_())).into(),
+            __current_scope(|b| b.call(Func::BufferSize, &[self_node], u32::type_())).into(),
         )
     }
 }
@@ -1892,13 +2009,15 @@ macro_rules! impl_atomic {
                 if need_runtime_check() {
                     lc_assert!(i.lt(self.len_expr()));
                 }
-                Expr::<$t>::from_node(__current_scope(|b| {
-                    b.call(
-                        Func::AtomicExchange,
-                        &[self.node, ToNode::node(&i), v.node()],
-                        <$t>::type_(),
-                    )
-                }))
+                let self_node = self.node.get();
+                let i = i.node().get();
+                let v = v.node().get();
+                Expr::<$t>::from_node(
+                    __current_scope(|b| {
+                        b.call(Func::AtomicExchange, &[self_node, i, v], <$t>::type_())
+                    })
+                    .into(),
+                )
             }
             pub fn atomic_compare_exchange<
                 I: IntoIndex,
@@ -1916,13 +2035,20 @@ macro_rules! impl_atomic {
                 if need_runtime_check() {
                     lc_assert!(i.lt(self.len_expr()));
                 }
-                Expr::<$t>::from_node(__current_scope(|b| {
-                    b.call(
-                        Func::AtomicCompareExchange,
-                        &[self.node, ToNode::node(&i), expected.node(), desired.node()],
-                        <$t>::type_(),
-                    )
-                }))
+                let self_node = self.node.get();
+                let i = i.node().get();
+                let expected = expected.node().get();
+                let desired = desired.node().get();
+                Expr::<$t>::from_node(
+                    __current_scope(|b| {
+                        b.call(
+                            Func::AtomicCompareExchange,
+                            &[self_node, i, expected, desired],
+                            <$t>::type_(),
+                        )
+                    })
+                    .into(),
+                )
             }
             pub fn atomic_fetch_add<I: IntoIndex, V: AsExpr<Value = $t>>(
                 &self,
@@ -1934,13 +2060,15 @@ macro_rules! impl_atomic {
                 if need_runtime_check() {
                     lc_assert!(i.lt(self.len_expr()));
                 }
-                Expr::<$t>::from_node(__current_scope(|b| {
-                    b.call(
-                        Func::AtomicFetchAdd,
-                        &[self.node, ToNode::node(&i), v.node()],
-                        <$t>::type_(),
-                    )
-                }))
+                let self_node = self.node.get();
+                let i = i.node().get();
+                let v = v.node().get();
+                Expr::<$t>::from_node(
+                    __current_scope(|b| {
+                        b.call(Func::AtomicFetchAdd, &[self_node, i, v], <$t>::type_())
+                    })
+                    .into(),
+                )
             }
             pub fn atomic_fetch_sub<I: IntoIndex, V: AsExpr<Value = $t>>(
                 &self,
@@ -1952,13 +2080,15 @@ macro_rules! impl_atomic {
                 if need_runtime_check() {
                     lc_assert!(i.lt(self.len_expr()));
                 }
-                Expr::<$t>::from_node(__current_scope(|b| {
-                    b.call(
-                        Func::AtomicFetchSub,
-                        &[self.node, ToNode::node(&i), v.node()],
-                        <$t>::type_(),
-                    )
-                }))
+                let self_node = self.node.get();
+                let i = i.node().get();
+                let v = v.node().get();
+                Expr::<$t>::from_node(
+                    __current_scope(|b| {
+                        b.call(Func::AtomicFetchSub, &[self_node, i, v], <$t>::type_())
+                    })
+                    .into(),
+                )
             }
             pub fn atomic_fetch_min<I: IntoIndex, V: AsExpr<Value = $t>>(
                 &self,
@@ -1970,13 +2100,15 @@ macro_rules! impl_atomic {
                 if need_runtime_check() {
                     lc_assert!(i.lt(self.len_expr()));
                 }
-                Expr::<$t>::from_node(__current_scope(|b| {
-                    b.call(
-                        Func::AtomicFetchMin,
-                        &[self.node, ToNode::node(&i), v.node()],
-                        <$t>::type_(),
-                    )
-                }))
+                let self_node = self.node.get();
+                let i = i.node().get();
+                let v = v.node().get();
+                Expr::<$t>::from_node(
+                    __current_scope(|b| {
+                        b.call(Func::AtomicFetchMin, &[self_node, i, v], <$t>::type_())
+                    })
+                    .into(),
+                )
             }
             pub fn atomic_fetch_max<I: IntoIndex, V: AsExpr<Value = $t>>(
                 &self,
@@ -1988,13 +2120,15 @@ macro_rules! impl_atomic {
                 if need_runtime_check() {
                     lc_assert!(i.lt(self.len_expr()));
                 }
-                Expr::<$t>::from_node(__current_scope(|b| {
-                    b.call(
-                        Func::AtomicFetchMax,
-                        &[self.node, ToNode::node(&i), v.node()],
-                        <$t>::type_(),
-                    )
-                }))
+                let self_node = self.node.get();
+                let i = i.node().get();
+                let v = v.node().get();
+                Expr::<$t>::from_node(
+                    __current_scope(|b| {
+                        b.call(Func::AtomicFetchMax, &[self_node, i, v], <$t>::type_())
+                    })
+                    .into(),
+                )
             }
         }
     };
@@ -2012,13 +2146,15 @@ macro_rules! impl_atomic_bit {
                 if need_runtime_check() {
                     lc_assert!(i.lt(self.len_expr()));
                 }
-                Expr::<$t>::from_node(__current_scope(|b| {
-                    b.call(
-                        Func::AtomicFetchAnd,
-                        &[self.node, ToNode::node(&i), v.node()],
-                        <$t>::type_(),
-                    )
-                }))
+                let self_node = self.node.get();
+                let i = i.node().get();
+                let v = v.node().get();
+                Expr::<$t>::from_node(
+                    __current_scope(|b| {
+                        b.call(Func::AtomicFetchAnd, &[self_node, i, v], <$t>::type_())
+                    })
+                    .into(),
+                )
             }
             pub fn atomic_fetch_or<I: IntoIndex, V: AsExpr<Value = $t>>(
                 &self,
@@ -2030,13 +2166,15 @@ macro_rules! impl_atomic_bit {
                 if need_runtime_check() {
                     lc_assert!(i.lt(self.len_expr()));
                 }
-                Expr::<$t>::from_node(__current_scope(|b| {
-                    b.call(
-                        Func::AtomicFetchOr,
-                        &[self.node, ToNode::node(&i), v.node()],
-                        <$t>::type_(),
-                    )
-                }))
+                let self_node = self.node.get();
+                let i = i.node().get();
+                let v = v.node().get();
+                Expr::<$t>::from_node(
+                    __current_scope(|b| {
+                        b.call(Func::AtomicFetchOr, &[self_node, i, v], <$t>::type_())
+                    })
+                    .into(),
+                )
             }
             pub fn atomic_fetch_xor<I: IntoIndex, V: AsExpr<Value = $t>>(
                 &self,
@@ -2048,13 +2186,15 @@ macro_rules! impl_atomic_bit {
                 if need_runtime_check() {
                     lc_assert!(i.lt(self.len_expr()));
                 }
-                Expr::<$t>::from_node(__current_scope(|b| {
-                    b.call(
-                        Func::AtomicFetchXor,
-                        &[self.node, ToNode::node(&i), v.node()],
-                        <$t>::type_(),
-                    )
-                }))
+                let self_node = self.node.get();
+                let i = i.node().get();
+                let v = v.node().get();
+                Expr::<$t>::from_node(
+                    __current_scope(|b| {
+                        b.call(Func::AtomicFetchXor, &[self_node, i, v], <$t>::type_())
+                    })
+                    .into(),
+                )
             }
         }
     };
@@ -2080,9 +2220,7 @@ pub struct Tex2dVar<T: IoTexel> {
 
 impl<T: IoTexel> Tex2dVar<T> {
     pub fn new(view: Tex2dView<'_, T>) -> Self {
-        let node = RECORDER.with(|r| {
-            let mut r = r.borrow_mut();
-            assert!(r.lock, "Tex2dVar<T> must be created from within a kernel");
+        let node = with_recorder(|r| {
             let handle: u64 = view.tex.handle().0;
             let binding = Binding::Texture(TextureBinding {
                 handle,
@@ -2136,9 +2274,7 @@ impl<T: IoTexel> Tex2dVar<T> {
 
 impl<T: IoTexel> Tex3dVar<T> {
     pub fn new(view: Tex3dView<'_, T>) -> Self {
-        let node = RECORDER.with(|r| {
-            let mut r = r.borrow_mut();
-            assert!(r.lock, "Tex3dVar<T> must be created from within a kernel");
+        let node = with_recorder(|r| {
             let handle: u64 = view.tex.handle().0;
             let binding = Binding::Texture(TextureBinding {
                 handle,

--- a/luisa_compute/src/runtime.rs
+++ b/luisa_compute/src/runtime.rs
@@ -1298,7 +1298,7 @@ impl<S: CallableSignature> DynCallable<S> {
             let mut r = r.borrow_mut();
             let device = r.device.clone().unwrap();
             (
-                std::mem::replace(&mut *r, Recorder::new()),
+                std::mem::replace(&mut *r, FnRecorder::new()),
                 device.upgrade().unwrap(),
             )
         });

--- a/luisa_compute/src/runtime/kernel.rs
+++ b/luisa_compute/src/runtime/kernel.rs
@@ -1,4 +1,4 @@
-use crate::lang::soa::SoaMetadata;
+use crate::lang::{pop_recorder, push_recorder, soa::SoaMetadata};
 
 use super::*;
 
@@ -188,18 +188,18 @@ impl_kernel_param_for_tuple!(T0 T1 T2 T3 T4 T5 T6 T7 T8 T9 T10 T11 T12 T13 T14 T
 impl KernelBuilder {
     pub fn new(device: Option<crate::runtime::Device>, is_kernel: bool) -> Self {
         RECORDER.with(|r| {
-            let mut r = r.borrow_mut();
-            assert!(!r.lock, "Cannot record multiple kernels at the same time");
-            assert!(
-                r.scopes.is_empty(),
-                "Cannot record multiple kernels at the same time"
-            );
-            r.lock = true;
+            let r = r.borrow();
+            if is_kernel {
+                assert!(r.is_none(), "Cannot record a kernel inside another kernel");
+            }
+        });
+        push_recorder();
+        with_recorder(|r| {
             r.device = device.as_ref().map(|d| WeakDevice::new(d));
-            r.pools = Some(CArc::new(ModulePools::new()));
+            r.pools = CArc::new(ModulePools::new());
             r.scopes.clear();
             r.building_kernel = is_kernel;
-            let pools = r.pools.clone().unwrap();
+            let pools = r.pools.clone();
             r.scopes.push(IrBuilder::new(pools));
         });
         Self {
@@ -217,11 +217,11 @@ impl KernelBuilder {
     }
     pub fn value<T: Value>(&mut self) -> Expr<T> {
         let node = self.arg(T::type_(), true);
-        FromNode::from_node(node)
+        FromNode::from_node(node.into())
     }
     pub fn var<T: Value>(&mut self) -> Var<T> {
         let node = self.arg(T::type_(), false);
-        FromNode::from_node(node)
+        FromNode::from_node(node.into())
     }
     pub fn uniform<T: Value>(&mut self) -> Expr<T> {
         let node = new_node(
@@ -229,7 +229,7 @@ impl KernelBuilder {
             Node::new(CArc::new(Instruction::Uniform), T::type_()),
         );
         self.args.push(node);
-        FromNode::from_node(node)
+        FromNode::from_node(node.into())
     }
     // pub fn byte_buffer(&mut self) -> ByteBufferVar {
     //     let node = new_node(
@@ -246,7 +246,7 @@ impl KernelBuilder {
         );
         self.args.push(node);
         BufferVar {
-            node,
+            node: node.into(),
             marker: PhantomData,
             handle: None,
         }
@@ -254,8 +254,8 @@ impl KernelBuilder {
     pub fn soa_buffer<T: SoaValue>(&mut self) -> SoaBufferVar<T> {
         let storage = self.buffer::<u8>();
         let metadata = self.buffer::<SoaMetadata>();
-        SoaBufferVar{
-            proxy: T::SoaBuffer::from_soa_storage(storage, metadata.read(0), 0)
+        SoaBufferVar {
+            proxy: T::SoaBuffer::from_soa_storage(storage, metadata.read(0), 0),
         }
     }
     pub fn tex2d<T: IoTexel>(&mut self) -> Tex2dVar<T> {
@@ -265,7 +265,7 @@ impl KernelBuilder {
         );
         self.args.push(node);
         Tex2dVar {
-            node,
+            node: node.into(),
             marker: PhantomData,
             handle: None,
             level: None,
@@ -278,7 +278,7 @@ impl KernelBuilder {
         );
         self.args.push(node);
         Tex3dVar {
-            node,
+            node: node.into(),
             marker: PhantomData,
             handle: None,
             level: None,
@@ -290,7 +290,10 @@ impl KernelBuilder {
             Node::new(CArc::new(Instruction::Bindless), Type::void()),
         );
         self.args.push(node);
-        BindlessArrayVar { node, handle: None }
+        BindlessArrayVar {
+            node: node.into(),
+            handle: None,
+        }
     }
     pub fn accel(&mut self) -> rtx::AccelVar {
         let node = new_node(
@@ -298,12 +301,14 @@ impl KernelBuilder {
             Node::new(CArc::new(Instruction::Accel), Type::void()),
         );
         self.args.push(node);
-        rtx::AccelVar { node, handle: None }
+        rtx::AccelVar {
+            node: node.into(),
+            handle: None,
+        }
     }
     fn collect_module_info(&self) -> (ResourceTracker, Vec<CArc<CpuCustomOp>>, Vec<Capture>) {
-        RECORDER.with(|r| {
+        with_recorder(|r| {
             let mut resource_tracker = ResourceTracker::new();
-            let r = r.borrow_mut();
             let mut captured: Vec<Capture> = Vec::new();
             let mut captured_resources: Vec<_> = r.captured_resources.values().cloned().collect();
             captured_resources.sort_by_key(|(i, _, _, _)| *i);
@@ -362,10 +367,7 @@ impl KernelBuilder {
         let ret = body(self);
         let ret_type = ret._return();
         let (rt, cpu_custom_ops, captures) = self.collect_module_info();
-        RECORDER.with(|r| {
-            let mut r = r.borrow_mut();
-            assert!(r.lock);
-            r.lock = false;
+        let ret = with_recorder(|r| {
             if let Some(t) = &r.callable_ret_type {
                 assert!(
                     luisa_compute_ir::context::is_type_equal(t, &ret_type),
@@ -380,27 +382,38 @@ impl KernelBuilder {
             let ir_module = Module {
                 entry,
                 kind: ModuleKind::Kernel,
-                pools: r.pools.clone().unwrap(),
+                pools: r.pools.clone(),
                 flags: ModuleFlags::REQUIRES_REV_AD_TRANSFORM
                     | ModuleFlags::REQUIRES_FWD_AD_TRANSFORM,
             };
             let ir_module = luisa_compute_ir::transform::luisa_compute_ir_transform_auto(ir_module);
+
+            let mut args = self.args.clone();
+            args.extend(r.captured_vars.values().map(|x| unsafe { x.get_raw() }));
+
             let module = CallableModule {
                 module: ir_module,
                 ret_type,
                 cpu_custom_ops: CBoxedSlice::new(cpu_custom_ops),
                 captures: CBoxedSlice::new(captures),
-                args: CBoxedSlice::new(self.args.clone()),
-                pools: r.pools.clone().unwrap(),
+                args: CBoxedSlice::new(args.clone()),
+                pools: r.pools.clone(),
             };
             let module = CallableModuleRef(CArc::new(module));
-            r.reset();
+
             RawCallable {
                 device: self.device.clone(),
                 module,
                 resource_tracker: rt,
+                captured_args: r
+                    .captured_vars
+                    .keys()
+                    .map(|x| unsafe { x.get_raw() })
+                    .collect(),
             }
-        })
+        });
+        pop_recorder();
+        ret
     }
 
     /// Don't use this directly
@@ -412,18 +425,15 @@ impl KernelBuilder {
     ) -> crate::runtime::KernelDef<S> {
         body(self);
         let (rt, cpu_custom_ops, captures) = self.collect_module_info();
-        RECORDER.with(|r| -> crate::runtime::KernelDef<S> {
-            let mut r = r.borrow_mut();
-            assert!(r.lock);
-            r.lock = false;
+        let ret = with_recorder(|r| {
             assert_eq!(r.scopes.len(), 1);
             let scope = r.scopes.pop().unwrap();
             let entry = scope.finish();
-
+            assert!(r.captured_vars.is_empty());
             let ir_module = Module {
                 entry,
                 kind: ModuleKind::Kernel,
-                pools: r.pools.clone().unwrap(),
+                pools: r.pools.clone(),
                 flags: ModuleFlags::REQUIRES_REV_AD_TRANSFORM
                     | ModuleFlags::REQUIRES_FWD_AD_TRANSFORM,
             };
@@ -435,9 +445,8 @@ impl KernelBuilder {
                 shared: CBoxedSlice::new(r.shared.clone()),
                 args: CBoxedSlice::new(self.args.clone()),
                 block_size: r.block_size.unwrap_or([64, 1, 1]),
-                pools: r.pools.clone().unwrap(),
+                pools: r.pools.clone(),
             };
-            r.reset();
 
             KernelDef {
                 inner: RawKernelDef {
@@ -447,7 +456,9 @@ impl KernelBuilder {
                 },
                 _marker: PhantomData,
             }
-        })
+        });
+        pop_recorder();
+        ret
     }
 }
 
@@ -514,7 +525,7 @@ unsafe impl<V: Value> CallableRet for Expr<V> {
         V::type_()
     }
     fn _from_return(node: NodeRef) -> Self {
-        Self::from_node(node)
+        Self::from_node(node.into())
     }
 }
 
@@ -529,7 +540,10 @@ macro_rules! impl_callable {
          }
         impl<R:CallableRet +'static, $($Ts: CallableParameter +'static),*> Callable<fn($($Ts,)*)->R> {
             pub fn new<F:Fn($($Ts,)*)->R>(device: &Device, f:F)->Self where F:CallableBuildFn<fn($($Ts,)*)->R> {
-                let mut builder = KernelBuilder::new(Some(device.clone()), false);
+                Self::new_maybe_device(Some(device.clone()), f)
+            }
+            pub fn new_maybe_device<F:Fn($($Ts,)*)->R>(device: Option<Device>, f:F)->Self where F:CallableBuildFn<fn($($Ts,)*)->R> {
+                let mut builder = KernelBuilder::new(device, false);
                 let raw_callable = CallableBuildFn::build_callable(&f, None, &mut builder);
                 Self{
                     inner: raw_callable,
@@ -539,12 +553,13 @@ macro_rules! impl_callable {
             pub fn new_static(f:fn($($Ts,)*)->R)->Self  where fn($($Ts,)*)->R :CallableBuildFn<fn($($Ts,)*)->R> {
                 let r_backup = RECORDER.with(|r| {
                     let mut r = r.borrow_mut();
-                    std::mem::replace(&mut *r, Recorder::new())
+                    std::mem::replace(&mut *r, Some(Rc::new(RefCell::new(FnRecorder::new()))))
                 });
                 let mut builder = KernelBuilder::new(None, false);
                 let raw_callable = CallableBuildFn::build_callable(&f, None, &mut builder);
                 RECORDER.with(|r| {
-                    *r.borrow_mut() = r_backup;
+                    let mut r = r.borrow_mut();
+                    *r = r_backup;
                 });
                 Self{
                     inner: raw_callable,

--- a/luisa_compute/src/runtime/kernel.rs
+++ b/luisa_compute/src/runtime/kernel.rs
@@ -507,8 +507,9 @@ unsafe impl CallableRet for () {
 
 unsafe impl<V: Value> CallableRet for Expr<V> {
     fn _return(&self) -> CArc<Type> {
+        let ret = self.node().get();
         __current_scope(|b| {
-            b.return_(self.node());
+            b.return_(ret);
         });
         V::type_()
     }

--- a/luisa_compute/tests/misc.rs
+++ b/luisa_compute/tests/misc.rs
@@ -1,3 +1,5 @@
+use std::cell::RefCell;
+
 use luisa::lang::ops::AddMaybeExpr;
 use luisa::lang::types::array::VLArrayVar;
 use luisa::lang::types::core::*;
@@ -48,7 +50,76 @@ fn event() {
     let v = a.copy_to_vec();
     assert_eq!(v[0], (1 + 3) * (4 + 5));
 }
+#[test]
+fn nested_callable_capture_by_value() {
+    let device = get_device();
+    let add = track!(Callable::<fn(Expr<f32>, Expr<f32>) -> Expr<f32>>::new(
+        &device,
+        |a, b| {
+            // callables can be defined within callables
+            let partial_add = Callable::<fn(Expr<f32>) -> Expr<f32>>::new(&device, |y| a + y);
+            partial_add.call(b)
+        }
+    ));
+    let x = device.create_buffer::<f32>(1024);
+    let y = device.create_buffer::<f32>(1024);
+    let z = device.create_buffer::<f32>(1024);
+    x.view(..).fill_fn(|i| i as f32);
+    y.view(..).fill_fn(|i| 1000.0 * i as f32);
+    let kernel = Kernel::<fn(Buffer<f32>)>::new(
+        &device,
+        &track!(|buf_z| {
+            let buf_x = x.var();
+            let buf_y = y.var();
+            let tid = dispatch_id().x;
+            let x = buf_x.read(tid);
+            let y = buf_y.read(tid);
 
+            buf_z.write(tid, add.call(x, y));
+        }),
+    );
+    kernel.dispatch([1024, 1, 1], &z);
+    let z_data = z.view(..).copy_to_vec();
+    for i in 0..x.len() {
+        assert_eq!(z_data[i], (i as f32 + 1000.0 * i as f32));
+    }
+}
+#[test]
+fn nested_callable_capture_by_ref() {
+    let device = get_device();
+    let add = track!(Callable::<fn(Expr<f32>, Expr<f32>) -> Expr<f32>>::new(
+        &device,
+        |a, b| {
+            let ret = a.var();
+            // callables can be defined within callables
+            let partial_add = Callable::<fn(Expr<f32>)>::new(&device, |y| *ret += y);
+            partial_add.call(b);
+            **ret
+        }
+    ));
+    let x = device.create_buffer::<f32>(1024);
+    let y = device.create_buffer::<f32>(1024);
+    let z = device.create_buffer::<f32>(1024);
+    x.view(..).fill_fn(|i| i as f32);
+    y.view(..).fill_fn(|i| 1000.0 * i as f32);
+    let kernel = Kernel::<fn(Buffer<f32>)>::new(
+        &device,
+        &track!(|buf_z| {
+            let buf_x = x.var();
+            let buf_y = y.var();
+            let tid = dispatch_id().x;
+            let x = buf_x.read(tid);
+            let y = buf_y.read(tid);
+
+            buf_z.write(tid, add.call(x, y));
+        }),
+    );
+    kernel.dispatch([1024, 1, 1], &z);
+    let z_data = z.view(..).copy_to_vec();
+    for i in 0..x.len() {
+        assert_eq!(z_data[i], (i as f32 + 1000.0 * i as f32));
+    }
+}
 #[test]
 #[should_panic]
 fn callable_different_device() {
@@ -105,6 +176,23 @@ fn callable_return_void_mismatch() {
                 return true.expr();
             }
             *x = -x;
+        }),
+    );
+}
+#[test]
+#[should_panic]
+fn callable_illegall_sharing() {
+    let device = get_device();
+    let tid = RefCell::new(None);
+    Kernel::<fn()>::new(&device, &|| {
+        let i = dispatch_id().x;
+        *tid.borrow_mut() = Some(i);
+    });
+    Kernel::<fn()>::new(
+        &device,
+        &track!(|| {
+            let tid = tid.borrow().unwrap();
+            let _i = dispatch_id().x + tid;
         }),
     );
 }
@@ -1229,7 +1317,7 @@ fn soa_view() {
     let bars_soa = device.create_soa_buffer::<Bar>(2048);
     bars_soa.view(..1024).copy_from_buffer(&bars);
     bars_soa.view(1024..2048).copy_from_buffer(&bars);
-    
+
     let also_bars = device.create_buffer(1024);
     bars_soa.view(..1024).copy_to_buffer(&also_bars);
     let bars_data = bars.view(..).copy_to_vec();

--- a/luisa_compute/tests/misc.rs
+++ b/luisa_compute/tests/misc.rs
@@ -1,11 +1,8 @@
 use std::cell::RefCell;
 
-use luisa::lang::ops::AddMaybeExpr;
 use luisa::lang::types::array::VLArrayVar;
-use luisa::lang::types::core::*;
 use luisa::lang::types::dynamic::*;
 use luisa::lang::types::vector::alias::*;
-use luisa::lang::types::ExprProxy;
 use luisa::prelude::*;
 use luisa_compute as luisa;
 use luisa_compute_api_types::StreamTag;
@@ -1101,6 +1098,7 @@ fn byte_buffer() {
 }
 
 #[test]
+#[allow(unused_assignments)]
 fn bindless_byte_buffer() {
     let device = get_device();
     let buf = device.create_byte_buffer(1024);
@@ -1119,6 +1117,7 @@ fn bindless_byte_buffer() {
             let view = buf.view(cnt..cnt + s);
             let bytes = unsafe { std::slice::from_raw_parts(&$v as *const $t as *const u8, s) };
             view.copy_from(bytes);
+
             cnt += s;
             old
         }};


### PR DESCRIPTION
1. Replace `NodeRef` with `SafeNodeRef`.
2. Allow nested callable definition and capturing of outer variables
3. Detect cross kernel node sharing