### PR TITLE
Implement dummy case for macOS to ensure that examples run using metal

### DIFF
--- a/luisa_compute/src/runtime.rs
+++ b/luisa_compute/src/runtime.rs
@@ -358,6 +358,7 @@ impl Device {
             }
             raw_window_handle::RawDisplayHandle::Wayland(h) => h.display.as_ptr() as u64,
             raw_window_handle::RawDisplayHandle::Windows(_h) => 0u64,
+            raw_window_handle::RawDisplayHandle::AppKit(_h) => 0,
             _ => todo!(),
         };
         self.create_swapchain_raw_handle(


### PR DESCRIPTION
This is fix that ensures that it can run in macOS using Metal.

As the AppKit raw handler doesn't store any data we can just use any value.